### PR TITLE
Implement support for Redis passwords in Django RQ

### DIFF
--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -10,6 +10,10 @@ def get_connection(name='default'):
     """
     from .settings import QUEUES
     queue_config = QUEUES[name]
+    if 'PASSWORD' in queue_config:
+        return redis.Redis(host=queue_config['HOST'],
+                           port=queue_config['PORT'], db=queue_config['DB'],
+                           password=queue_config['PASSWORD'])        
     return redis.Redis(host=queue_config['HOST'],
         port=queue_config['PORT'], db=queue_config['DB'])
 


### PR DESCRIPTION
I added a check in queues.py to see if a password was provided as part of the queue config in settings.py: if one was then use it when returning a Redis connection: this permits the use of Django RQ with password-protected Redis instances (useful for operating in certain shared networking environments).
