### PR TITLE
Allow simple syntax for `job` decorator.

### DIFF
--- a/django_rq/decorators.py
+++ b/django_rq/decorators.py
@@ -1,20 +1,33 @@
-from rq.decorators import job
+from rq.decorators import job as _rq_job
 
 from .queues import get_queue
 
 
-class job(job):
+def job(func_or_queue, connection=None, *args, **kwargs):
     """
     The same as RQ's job decorator, but it works automatically works out
     the ``connection`` argument from RQ_QUEUES.
-    """
 
-    def __init__(self, queue, connection=None, *args, **kwargs):        
-        if isinstance(queue, basestring):
-            try:
-                queue = get_queue(queue)
-                if connection is None:
-                    connection = queue.connection
-            except KeyError:
-                pass
-        super(job, self).__init__(queue, connection, *args, **kwargs)
+    And also, it allows simplified ``@job`` syntax to put job into
+    default queue.
+    """
+    if callable(func_or_queue):
+        func = func_or_queue
+        queue = 'default'
+    else:
+        func = None
+        queue = func_or_queue
+
+    if isinstance(queue, basestring):
+        try:
+            queue = get_queue(queue)
+            if connection is None:
+                connection = queue.connection
+        except KeyError:
+            pass
+
+    decorator = _rq_job(queue, connection=connection, *args, **kwargs)
+    if func:
+        return decorator(func)
+    return decorator
+


### PR DESCRIPTION
It is nice to use simple syntax:

```
@job
def some_func():
    pass
```

in cases, when you have only 'default' queue.
