### PR TITLE
Custom worker classes and ttl settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,6 +143,11 @@ If you want to run ``rqworker`` in burst mode, you can pass in the ``--burst`` f
 
     python manage.py rqworker high default low --burst
 
+If you need to use a custom worker class, you can pass in the ``--worker-class`` flag
+with the path to your worker::
+    
+    python manage.py rqworker high default low --worker-class 'path.to.GeventWorker'
+    
 Support for RQ Scheduler
 ------------------------
 


### PR DESCRIPTION
This is for issue #43.

RQ's `rqworker` command has the ability to set custom worker classes and result- and worker- ttl.
