### PR TITLE
don't rely on rq.utils.import_attribute

### DIFF
--- a/django_rq/management/commands/rqworker.py
+++ b/django_rq/management/commands/rqworker.py
@@ -42,6 +42,7 @@ if not logger.handlers:
     })
 
     
+# Copied from rq.utils
 def import_attribute(name):
     """Return an attribute from a dotted path name (e.g. "path.to.func")."""
     module_name, attribute = name.rsplit('.', 1)


### PR DESCRIPTION
Copied the import_attribute function into the rqworker command so that we don't depend on rq providing that function.

Discussed in ui/rq-scheduler#35
