### PR TITLE
Fixed: job.status is deprecated since python-rq 4.0, use get_status when...

### DIFF
--- a/django_rq/templates/django_rq/job_detail.html
+++ b/django_rq/templates/django_rq/job_detail.html
@@ -78,7 +78,13 @@
         <div class="form-row">
             <div>
                 <label class="required">Status:</label>
-                <div class="data">{{ job.status }}</div>
+                <div class="data">
+                    {% if job.get_status %}
+                        {{ job.get_status }}
+                    {% else %}
+                        {{ job.status }}
+                    {% endif %}
+                </div>
             </div>
         </div>
 

--- a/django_rq/templates/django_rq/jobs.html
+++ b/django_rq/templates/django_rq/jobs.html
@@ -42,7 +42,13 @@
                         </th>
                         <td>{{ job.created_at }}</td>
                         <td>{{ job.enqueued_at }}</td>
-                        <td>{{ job.status }}</td>
+                        <td>
+                            {% if job.get_status %}
+                                {{ job.get_status }}
+                            {% else %}
+                                {{ job.status }}
+                            {% endif %}
+                        </td>
                         <td>{{ job.func_name }}</td>
                     </tr>
                 {% endfor %}


### PR DESCRIPTION
... available
