### PR TITLE
Added --name parameter to rqworker management task

### DIFF
--- a/django_rq/management/commands/rqworker.py
+++ b/django_rq/management/commands/rqworker.py
@@ -88,7 +88,7 @@ class Command(BaseCommand):
             # Instantiate a worker
             worker_class = import_attribute(options.get('worker_class', 'rq.Worker'))
             queues = get_queues(*args)
-            w = worker_class(queues, connection=queues[0].connection, name=options.get('name', None))
+            w = worker_class(queues, connection=queues[0].connection, name=options['name'])
 
             # Call use_connection to push the redis connection into LocalStack
             # without this, jobs using RQ's get_current_job() will fail


### PR DESCRIPTION
Add the ability to name a worker (instead of the default concatenation of the current hostname and the current PID), just as in the python-rq rqworker script.

I use this to give meaningful names to workers of different queues in my custom admin dashboard. Created a pull request because it might be useful for others too..
