### PR TITLE
Added ability to connect to Redis via UNIX socket

### DIFF
--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -74,7 +74,7 @@ def get_redis_connection(config):
             return cache._client
         
     if 'UNIX_SOCKET_PATH' in config:
-        return redis.Redis(unix_socket_path=config['UNIX_SOCKET_PATH'])
+        return redis.Redis(unix_socket_path=config['UNIX_SOCKET_PATH'], db=config['DB'])
 
     return redis.Redis(host=config['HOST'],
                        port=config['PORT'], db=config['DB'],


### PR DESCRIPTION
I quickly added one if-case that checks for the "UNIX_SOCKET_PATH" variable in the RQ_QUEUES settings. My host only allows me to connect to Redis via Socket, so I had to do this little patch.
