### PR TITLE
Ignore DEFAULT_TIMEOUT parameter when comparing Redis connections.

### DIFF
--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -139,7 +139,10 @@ def filter_connection_params(queue_params):
     Filters the queue params to keep only the connection related params.
     """
     NON_CONNECTION_PARAMS = ('DEFAULT_TIMEOUT',)
-    return {p:v for p,v in queue_params.items() if p not in NON_CONNECTION_PARAMS}
+    
+    #return {p:v for p,v in queue_params.items() if p not in NON_CONNECTION_PARAMS}
+    # Dict comprehension compatible with python 2.6
+    return dict((p,v) for (p,v) in queue_params.items() if p not in NON_CONNECTION_PARAMS)
 
     
 def get_queues(*queue_names, **kwargs):


### PR DESCRIPTION
Fix the bug that prevents from having a different DEFAULT_TIMEOUT parameter for each queue.
https://github.com/ui/django-rq/issues/79
https://github.com/ui/django-rq/issues/71
