### PR TITLE
"None" is a valid job_status.

### DIFF
--- a/django_rq/templates/django_rq/jobs.html
+++ b/django_rq/templates/django_rq/jobs.html
@@ -85,7 +85,7 @@
                                 <td>{{ job.created_at }}</td>
                                 <td>{{ job.enqueued_at }}</td>
                                 <td>
-                                    {% if job.get_status %}
+                                    {% if job.get_status|length != 0 %}
                                         {{ job.get_status }}
                                     {% else %}
                                         {{ job.status }}


### PR DESCRIPTION
Jobs on a queue with no worker have a status of `None`. The if statement sees this as a falsy value, which results in job.status being evaluated, which then raises a deprecation error on recent versions of RQ.

There's no `defined` filter in django templates, but django casts all results to strings, so a status of `None` will have a length, whereas an undefined function will have a length of 0.
