### PR TITLE
Add scheduled jobs column

### DIFF
--- a/django_rq/templates/django_rq/stats.html
+++ b/django_rq/templates/django_rq/stats.html
@@ -75,7 +75,7 @@
                     {% if display_scheduled_jobs %}
                         <td>
                             {% if queue.name != 'failed' %}
-                                <a href = "todo">
+                                <a href = "{% url 'rq_scheduled_jobs' queue.index %}">
                                     {{ queue.scheduled_jobs }}
                                 </a>
                             {% else %}

--- a/django_rq/templates/django_rq/stats.html
+++ b/django_rq/templates/django_rq/stats.html
@@ -27,6 +27,9 @@
                     <th>Active Jobs</th>
                     <th>Deferred Jobs</th>
                     <th>Finished Jobs</th>
+                {% if display_scheduled_jobs %}
+                    <th>Scheduled Jobs</th>
+                {% endif %}
                     <th>Number of Workers</th>
                     <th>Host</th>
                     <th>Port</th>
@@ -69,6 +72,17 @@
                                 -
                             {% endif %}
                         </td>
+                    {% if display_scheduled_jobs %}
+                        <td>
+                            {% if queue.name != 'failed' %}
+                                <a href = "todo">
+                                    {{ queue.scheduled_jobs }}
+                                </a>
+                            {% else %}
+                                -
+                            {% endif %}
+                        </td>
+                    {% endif %}
                         <td>{{ queue.workers }}</td>
                         <td>{{ queue.connection_kwargs.host }}</td>
                         <td>{{ queue.connection_kwargs.port }}</td>

--- a/django_rq/urls.py
+++ b/django_rq/urls.py
@@ -13,6 +13,8 @@ urlpatterns = [
         views.started_jobs, name='rq_started_jobs'),
     url(r'^queues/(?P<queue_index>[\d]+)/deferred/$',
         views.deferred_jobs, name='rq_deferred_jobs'),
+    url(r'^queues/(?P<queue_index>[\d]+)/scheduled/$',
+        views.scheduled_jobs, name='rq_scheduled_jobs'),
     url(r'^queues/(?P<queue_index>[\d]+)/empty/$',
         views.clear_queue, name='rq_clear'),
     url(r'^queues/(?P<queue_index>[\d]+)/(?P<job_id>[-\w]+)/$',

--- a/django_rq/views.py
+++ b/django_rq/views.py
@@ -62,7 +62,8 @@ def stats(request):
 
             if DISPLAY_SCHEDULER:
                scheduler = get_scheduler(queue.name)
-               queue_data['scheduled_jobs'] = len(scheduler.get_jobs())
+               queue_data['scheduled_jobs'] = len([job for job in scheduler.get_jobs()
+                                                    if job.origin == queue.name])
 
         queues.append(queue_data)
 


### PR DESCRIPTION
This adds:
- [x] A column to display scheduled jobs per queue on the stats page when [rq-scheduler](https://github.com/ui/rq-scheduler) is installed.
- [x] A view to list scheduled jobs for the queue.
- [x] Tests

I didn't dig deep much into the `jobs.html` template though most of the columns are not useful for schedulued jobs.
