### PR TITLE
Broken Dependency Fix

### DIFF
--- a/django_rq/templates/django_rq/job_detail.html
+++ b/django_rq/templates/django_rq/job_detail.html
@@ -97,7 +97,7 @@
                 <label class="required">Dependency:</label>
                 <div class="data">
                   <a href = "{% url 'rq_job_detail' queue_index job.dependency.id %}">
-                    {{ job.dependency.func_name }}
+                    {{ job.dependency.id }} {{ job.dependency.func_name }}
                   </a>
                 </div>
             </div>

--- a/django_rq/templates/django_rq/job_detail.html
+++ b/django_rq/templates/django_rq/job_detail.html
@@ -68,12 +68,14 @@
             </div>
         </div>
 
+        {% if job.enqueued_at %}
         <div class="form-row">
             <div>
                 <label class="required">Queued:</label>
                 <div class="data">{{ job.enqueued_at|to_localtime }}</div>
             </div>
         </div>
+        {% endif %}
 
         <div class="form-row">
             <div>

--- a/django_rq/templates/django_rq/job_detail.html
+++ b/django_rq/templates/django_rq/job_detail.html
@@ -91,6 +91,19 @@
             </div>
         </div>
 
+        {% if job.dependency %}
+        <div class="form-row">
+            <div>
+                <label class="required">Dependency:</label>
+                <div class="data">
+                  <a href = "{% url 'rq_job_detail' queue_index job.dependency.id %}">
+                    {{ job.dependency.func_name }}
+                  </a>
+                </div>
+            </div>
+        </div>
+        {% endif %}
+
         <div class="form-row">
             <div>
                 <label class="required">Args:</label>

--- a/django_rq/templates/django_rq/jobs.html
+++ b/django_rq/templates/django_rq/jobs.html
@@ -85,7 +85,13 @@
                                     </a>
                                 </th>
                                 <td>{{ job.created_at|to_localtime }}</td>
-                                <td>{{ job.enqueued_at|to_localtime }}</td>
+                                <td>
+                                  {% if job.enqueued_at %}
+                                    {{ job.enqueued_at|to_localtime }}
+                                  {% else %}
+                                    Deferred
+                                  {% endif %}
+                                </td>
                                 <td>{{ job.get_status }}</td>
                                 <td>{{ job.func_name }}</td>
                             </tr>

--- a/django_rq/views.py
+++ b/django_rq/views.py
@@ -223,6 +223,7 @@ def job_detail(request, queue_index, job_id):
     try:
         job.dependency
     except Exception as e:
+        dependency_id = job.__dict__['_dependency_id']
         # remove the dependency association
         job.connection.srem(job.dependents_key_for(dependency_id), job.id)
         # set this job as failed (for requeing WITHOUT dependency)


### PR DESCRIPTION
When a job depends on another that is deleted, it becomes stranded, cannot be requeued, and ends up serving a 500.

This fix allows for:

* Rescuing
* Fixing job to have no dependency
* Moving it to failed queue where it can be requeued

I added to [the rq handling discussion](https://github.com/nvie/rq/pull/427#issuecomment-317022979)