### PR TITLE
More consistent usage of queue class / worker class overriding

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -140,6 +140,18 @@ decorator that comes with ``django_rq``:
         pass
     long_running_func.delay() # Enqueue function in "high" queue
 
+It's possible to specify default for ``result_ttl`` decorator keyword argument
+via ``DEFAULT_RESULT_TTL`` setting:
+
+.. code-block:: python
+
+    RQ = {
+        'DEFAULT_RESULT_TTL': 5000,
+    }
+
+With this setting, job decorator will set ``result_ttl`` to 5000 unless it's
+specified explicitly.
+
 
 Running workers
 ---------------

--- a/README.rst
+++ b/README.rst
@@ -164,8 +164,8 @@ If you want to run ``rqworker`` in burst mode, you can pass in the ``--burst`` f
 
     python manage.py rqworker high default low --burst
 
-If you need to use custom worker or queue classes, it is best to use global settings
-(see `Custom queue classes`_ and `Custom worker class`_). However, it is also possible
+If you need to use custom worker, job or queue classes, it is best to use global settings
+(see `Custom queue classes`_ and `Custom job and worker classes`_). However, it is also possible
 to override such settings with command line options as follows.
 
 To use a custom worker class, you can pass in the ``--worker-class`` flag
@@ -177,6 +177,8 @@ To use a custom queue class, you can pass in the ``--queue-class`` flag
 with the path to your queue class::
 
     python manage.py rqworker high default low --queue-class 'path.to.CustomQueue'
+
+To use a custom job class, provide ``--job-class`` flag.
 
 Support for RQ Scheduler
 ------------------------
@@ -349,17 +351,26 @@ or you can specify ``DjangoRQ`` to use a custom class for all your queues in ``R
 
 Custom queue classes should inherit from ``django_rq.queues.DjangoRQ``.
 
-Custom worker class
--------------------
+If you are using more than one queue class (not recommended), be sure to only run workers
+on queues with same queue class. For example if you have two queues defined in ``RQ_QUEUES`` and
+one has custom class specified, you would have to run at least two separate workers for each
+queue.
 
-Similarly to custom queue classes, global custom worker class can be configured using
-``WORKER_CLASS`` setting:
+Custom job and worker classes
+-----------------------------
+
+Similarly to custom queue classes, global custom job and worker classes can be configured using
+``JOB_CLASS`` and ``WORKER_CLASS`` settings:
 
 .. code-block:: python
 
     RQ = {
+        'JOB_CLASS': 'module.path.CustomJobClass',
         'WORKER_CLASS': 'module.path.CustomWorkerClass',
     }
+
+Custom job class should inherit from ``rq.job.Job``. It will be used for all jobs
+if configured.
 
 Custom worker class should inherit from ``rq.worker.Worker``. It will be used for running
 all workers unless overriden by ``rqworker`` management command ``worker-class`` option.

--- a/README.rst
+++ b/README.rst
@@ -152,12 +152,16 @@ If you want to run ``rqworker`` in burst mode, you can pass in the ``--burst`` f
 
     python manage.py rqworker high default low --burst
 
-If you need to use a custom worker class, you can pass in the ``--worker-class`` flag
+If you need to use custom worker or queue classes, it is best to use global settings
+(see `Custom queue classes`_ and `Custom worker class`_). However, it is also possible
+to override such settings with command line options as follows.
+
+To use a custom worker class, you can pass in the ``--worker-class`` flag
 with the path to your worker::
 
     python manage.py rqworker high default low --worker-class 'path.to.GeventWorker'
 
-If you need to use a custom queue class, you can pass in the ``--queue-class`` flag
+To use a custom queue class, you can pass in the ``--queue-class`` flag
 with the path to your queue class::
 
     python manage.py rqworker high default low --queue-class 'path.to.CustomQueue'
@@ -332,6 +336,21 @@ or you can specify ``DjangoRQ`` to use a custom class for all your queues in ``R
     }
 
 Custom queue classes should inherit from ``django_rq.queues.DjangoRQ``.
+
+Custom worker class
+-------------------
+
+Similarly to custom queue classes, global custom worker class can be configured using
+``WORKER_CLASS`` setting:
+
+.. code-block:: python
+
+    RQ = {
+        'WORKER_CLASS': 'module.path.CustomWorkerClass',
+    }
+
+Custom worker class should inherit from ``rq.worker.Worker``. It will be used for running
+all workers unless overriden by ``rqworker`` management command ``worker-class`` option.
 
 Testing tip
 -----------

--- a/django_rq/decorators.py
+++ b/django_rq/decorators.py
@@ -1,16 +1,21 @@
-from django.utils import six
 from rq.decorators import job as _rq_job
+
+from django.conf import settings
+from django.utils import six
 
 from .queues import get_queue
 
 
 def job(func_or_queue, connection=None, *args, **kwargs):
     """
-    The same as RQ's job decorator, but it works automatically works out
+    The same as RQ's job decorator, but it automatically works out
     the ``connection`` argument from RQ_QUEUES.
 
     And also, it allows simplified ``@job`` syntax to put job into
     default queue.
+
+    If RQ.DEFAULT_RESULT_TTL setting is set, it is used as default
+    for ``result_ttl`` kwarg.
     """
     if callable(func_or_queue):
         func = func_or_queue
@@ -26,6 +31,11 @@ def job(func_or_queue, connection=None, *args, **kwargs):
                 connection = queue.connection
         except KeyError:
             pass
+
+    RQ = getattr(settings, 'RQ', {})
+    default_result_ttl = RQ.get('DEFAULT_RESULT_TTL')
+    if default_result_ttl:
+        kwargs.setdefault('result_ttl', default_result_ttl)
 
     decorator = _rq_job(queue, connection=connection, *args, **kwargs)
     if func:

--- a/django_rq/jobs.py
+++ b/django_rq/jobs.py
@@ -1,0 +1,23 @@
+from rq.job import Job
+from rq.utils import import_attribute
+
+from django.conf import settings
+from django.utils import six
+
+
+def get_job_class(job_class=None):
+    """
+    Return job class from RQ settings, otherwise return Job.
+    If `job_class` is not None, it is used as an override (can be
+    python import path as string).
+    """
+    RQ = getattr(settings, 'RQ', {})
+
+    if job_class is None:
+        job_class = Job
+        if 'JOB_CLASS' in RQ:
+            job_class = RQ.get('JOB_CLASS')
+
+    if isinstance(job_class, six.string_types):
+        job_class = import_attribute(job_class)
+    return job_class

--- a/django_rq/jobs.py
+++ b/django_rq/jobs.py
@@ -14,9 +14,7 @@ def get_job_class(job_class=None):
     RQ = getattr(settings, 'RQ', {})
 
     if job_class is None:
-        job_class = Job
-        if 'JOB_CLASS' in RQ:
-            job_class = RQ.get('JOB_CLASS')
+        job_class = RQ.get('JOB_CLASS', Job)
 
     if isinstance(job_class, six.string_types):
         job_class = import_attribute(job_class)

--- a/django_rq/management/commands/rqworker.py
+++ b/django_rq/management/commands/rqworker.py
@@ -5,14 +5,12 @@ from distutils.version import LooseVersion
 
 from redis.exceptions import ConnectionError
 from rq import use_connection
-from rq.utils import ColorizingStreamHandler, import_attribute
+from rq.utils import ColorizingStreamHandler
 
 from django.core.management.base import BaseCommand
 from django.db import connections
-from django.utils import six
 from django.utils.version import get_version
-from django_rq.queues import get_queue_class, get_queues
-from django_rq.workers import get_exception_handlers, get_worker_class
+from django_rq.workers import get_worker
 
 # Setup logging for RQWorker if not already configured
 logger = logging.getLogger('rq.worker')
@@ -52,6 +50,8 @@ class Command(BaseCommand):
                             default=None, help='Name of the worker')
         parser.add_argument('--queue-class', action='store', dest='queue_class',
                             help='Queues class to use')
+        parser.add_argument('--job-class', action='store', dest='job_class',
+                            help='Jobs class to use')
         parser.add_argument('--worker-ttl', action='store', type=int,
                             dest='worker_ttl', default=420,
                             help='Default worker timeout to be used')
@@ -70,19 +70,14 @@ class Command(BaseCommand):
         sentry_dsn = options.get('sentry-dsn')
         try:
             # Instantiate a worker
-            worker_class = get_worker_class(options['worker_class'])
-            queue_class = options['queue_class'] or get_queue_class({})
-            if isinstance(queue_class, six.string_types):
-                queue_class = import_attribute(queue_class)
-            queues = get_queues(*args, **{'queue_class': queue_class})
-            w = worker_class(
-                queues,
-                connection=queues[0].connection,
-                name=options['name'],
-                exception_handlers=get_exception_handlers() or None,
-                default_worker_ttl=options['worker_ttl'],
-                queue_class=queue_class
-            )
+            worker_kwargs = {
+                'worker_class': options['worker_class'],
+                'queue_class': options['queue_class'],
+                'job_class': options['job_class'],
+                'name': options['name'],
+                'default_worker_ttl': options['worker_ttl'],
+            }
+            w = get_worker(*args, **worker_kwargs)
 
             # Call use_connection to push the redis connection into LocalStack
             # without this, jobs using RQ's get_current_job() will fail

--- a/django_rq/management/commands/rqworker.py
+++ b/django_rq/management/commands/rqworker.py
@@ -1,19 +1,17 @@
-from distutils.version import LooseVersion
-import os
-import importlib
 import logging
+import os
 import sys
+from distutils.version import LooseVersion
+
+from redis.exceptions import ConnectionError
+from rq import use_connection
+from rq.utils import ColorizingStreamHandler, import_attribute
 
 from django.core.management.base import BaseCommand
 from django.db import connections
 from django.utils.version import get_version
-
 from django_rq.queues import get_queues
-from django_rq.workers import get_exception_handlers
-
-from redis.exceptions import ConnectionError
-from rq import use_connection
-from rq.utils import ColorizingStreamHandler
+from django_rq.workers import get_exception_handlers, get_worker_class
 
 # Setup logging for RQWorker if not already configured
 logger = logging.getLogger('rq.worker')
@@ -24,14 +22,6 @@ if not logger.handlers:
     handler = ColorizingStreamHandler()
     handler.setFormatter(formatter)
     logger.addHandler(handler)
-
-
-# Copied from rq.utils
-def import_attribute(name):
-    """Return an attribute from a dotted path name (e.g. "path.to.func")."""
-    module_name, attribute = name.rsplit('.', 1)
-    module = importlib.import_module(module_name)
-    return getattr(module, attribute)
 
 
 def reset_db_connections():
@@ -52,7 +42,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('--worker-class', action='store', dest='worker_class',
-                            default='rq.Worker', help='RQ Worker class to use')
+                            help='RQ Worker class to use')
         parser.add_argument('--pid', action='store', dest='pid',
                             default=None, help='PID file to write the worker`s pid into')
         parser.add_argument('--burst', action='store_true', dest='burst',
@@ -60,7 +50,7 @@ class Command(BaseCommand):
         parser.add_argument('--name', action='store', dest='name',
                             default=None, help='Name of the worker')
         parser.add_argument('--queue-class', action='store', dest='queue_class',
-                            default='django_rq.queues.DjangoRQ', help='Queues class to use')
+                            help='Queues class to use')
         parser.add_argument('--worker-ttl', action='store', type=int,
                             dest='worker_ttl', default=420,
                             help='Default worker timeout to be used')
@@ -79,8 +69,12 @@ class Command(BaseCommand):
         sentry_dsn = options.get('sentry-dsn')
         try:
             # Instantiate a worker
-            worker_class = import_attribute(options['worker_class'])
-            queues = get_queues(*args, queue_class=import_attribute(options['queue_class']))
+            worker_class = get_worker_class(options['worker_class'])
+            get_queues_kwargs = {}
+            queue_class = options['queue_class']
+            if queue_class is not None:
+                get_queues_kwargs['queue_class'] = import_attribute(queue_class)
+            queues = get_queues(*args, **get_queues_kwargs)
             w = worker_class(
                 queues,
                 connection=queues[0].connection,

--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -206,7 +206,7 @@ def get_queues(*queue_names, **kwargs):
     # do consistency checks while building return list
     for name in queue_names[1:]:
         queue = get_queue(name, **kwargs)
-        if queue.__class__ is not queues[0].__class__:
+        if type(queue) is not type(queues[0]):
             raise ValueError(
                 'Queues must have the same class.'
                 '"{0}" and "{1}" have '

--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -27,15 +27,19 @@ def get_commit_mode():
 
 def get_queue_class(config=None, queue_class=None):
     """
-    Return queue class from config or from RQ settings, otherwise return DjangoRQ
+    Return queue class from config or from RQ settings, otherwise return DjangoRQ.
+    If ``queue_class`` is provided, it takes priority.
+
+    The full priority list for queue class sources:
+    1. ``queue_class`` argument
+    2. ``QUEUE_CLASS`` in ``config`` argument
+    3. ``QUEUE_CLASS`` in base settings (``RQ``)
     """
     RQ = getattr(settings, 'RQ', {})
     if queue_class is None:
-        queue_class = DjangoRQ
-        if config is not None and 'QUEUE_CLASS' in config:
-            queue_class = config.get('QUEUE_CLASS')
-        elif 'QUEUE_CLASS' in RQ:
-            queue_class = RQ.get('QUEUE_CLASS')
+        queue_class = RQ.get('QUEUE_CLASS', DjangoRQ)
+        if config:
+            queue_class = config.get('QUEUE_CLASS', queue_class)
 
     if isinstance(queue_class, six.string_types):
         queue_class = import_attribute(queue_class)

--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -25,14 +25,14 @@ def get_commit_mode():
     return RQ.get('AUTOCOMMIT', True)
 
 
-def get_queue_class(config={}, queue_class=None):
+def get_queue_class(config=None, queue_class=None):
     """
     Return queue class from config or from RQ settings, otherwise return DjangoRQ
     """
     RQ = getattr(settings, 'RQ', {})
     if queue_class is None:
         queue_class = DjangoRQ
-        if 'QUEUE_CLASS' in config:
+        if config is not None and 'QUEUE_CLASS' in config:
             queue_class = config.get('QUEUE_CLASS')
         elif 'QUEUE_CLASS' in RQ:
             queue_class = RQ.get('QUEUE_CLASS')
@@ -197,12 +197,12 @@ def get_queues(*queue_names, **kwargs):
 
     queue_params = QUEUES[queue_names[0]]
     connection_params = filter_connection_params(queue_params)
-    ret = [get_queue(queue_names[0], **kwargs)]
+    queues = [get_queue(queue_names[0], **kwargs)]
 
     # do consistency checks while building return list
     for name in queue_names[1:]:
         queue = get_queue(name, **kwargs)
-        if queue.__class__ is not ret[0].__class__:
+        if queue.__class__ is not queues[0].__class__:
             raise ValueError(
                 'Queues must have the same class.'
                 '"{0}" and "{1}" have '
@@ -212,9 +212,9 @@ def get_queues(*queue_names, **kwargs):
                 'Queues must have the same redis connection.'
                 '"{0}" and "{1}" have '
                 'different connections'.format(name, queue_names[0]))
-        ret.append(queue)
+        queues.append(queue)
 
-    return ret
+    return queues
 
 
 def enqueue(func, *args, **kwargs):

--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -167,11 +167,12 @@ def filter_connection_params(queue_params):
     """
     Filters the queue params to keep only the connection related params.
     """
-    NON_CONNECTION_PARAMS = ('DEFAULT_TIMEOUT',)
+    CONNECTION_PARAMS = ('URL', 'DB', 'USE_REDIS_CACHE',
+                         'UNIX_SOCKET_PATH', 'HOST', 'PORT', 'PASSWORD')
 
-    #return {p:v for p,v in queue_params.items() if p not in NON_CONNECTION_PARAMS}
+    #return {p:v for p,v in queue_params.items() if p in CONNECTION_PARAMS}
     # Dict comprehension compatible with python 2.6
-    return dict((p,v) for (p,v) in queue_params.items() if p not in NON_CONNECTION_PARAMS)
+    return dict((p,v) for (p,v) in queue_params.items() if p in CONNECTION_PARAMS)
 
 
 def get_queues(*queue_names, **kwargs):

--- a/django_rq/settings.py
+++ b/django_rq/settings.py
@@ -5,8 +5,6 @@ from django.core.exceptions import ImproperlyConfigured
 
 from .queues import get_unique_connection_configs
 
-RQ = getattr(settings, 'RQ', {})
-
 SHOW_ADMIN_LINK = getattr(settings, 'RQ_SHOW_ADMIN_LINK', False)
 
 QUEUES = getattr(settings, 'RQ_QUEUES', None)

--- a/django_rq/settings.py
+++ b/django_rq/settings.py
@@ -5,6 +5,8 @@ from django.core.exceptions import ImproperlyConfigured
 
 from .queues import get_unique_connection_configs
 
+RQ = getattr(settings, 'RQ', {})
+
 SHOW_ADMIN_LINK = getattr(settings, 'RQ_SHOW_ADMIN_LINK', False)
 
 QUEUES = getattr(settings, 'RQ_QUEUES', None)

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -550,10 +550,10 @@ class ViewTest(TestCase):
         worker1 = get_worker()
         worker2 = get_worker('test')
         workers_collections = [
-            {'config': {'some_config': 1}, 'all_workers': [worker1]},
-            {'config': {'some_config': 2}, 'all_workers': [worker2]},
+            {'config': {'URL': 'redis://'}, 'all_workers': [worker1]},
+            {'config': {'URL': 'redis://localhost/1'}, 'all_workers': [worker2]},
         ]
-        result = get_all_workers_by_configuration({'some_config': 1}, workers_collections)
+        result = get_all_workers_by_configuration({'URL': 'redis://'}, workers_collections)
         self.assertEqual(result, [worker1])
 
     def test_workers(self):

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -363,6 +363,24 @@ class DecoratorTest(TestCase):
         self.assertEqual(result.origin, 'default')
         result.delete()
 
+    def test_job_decorator_result_ttl_default(self):
+        from rq.defaults import DEFAULT_RESULT_TTL
+
+        @job
+        def test():
+            pass
+        result = test.delay()
+        self.assertEqual(result.result_ttl, DEFAULT_RESULT_TTL)
+        result.delete()
+
+    @override_settings(RQ={'AUTOCOMMIT': True, 'DEFAULT_RESULT_TTL': 5432})
+    def test_job_decorator_result_ttl(self):
+        @job
+        def test():
+            pass
+        result = test.delay()
+        self.assertEqual(result.result_ttl, 5432)
+        result.delete()
 
 @override_settings(RQ={'AUTOCOMMIT': True})
 class WorkersTest(TestCase):

--- a/django_rq/workers.py
+++ b/django_rq/workers.py
@@ -1,6 +1,7 @@
 from rq import Worker
 from rq.utils import import_attribute
 
+from django.conf import settings as global_settings
 from django.utils import six
 
 from . import settings
@@ -24,7 +25,7 @@ def get_worker_class(worker_class=None):
     python import path as string).
     """
     if worker_class is None:
-        RQ = getattr(settings, 'RQ', {})
+        RQ = getattr(global_settings, 'RQ', {})
         worker_class = Worker
         if 'WORKER_CLASS' in RQ:
             worker_class = RQ.get('WORKER_CLASS')

--- a/django_rq/workers.py
+++ b/django_rq/workers.py
@@ -50,9 +50,9 @@ def collect_workers_by_connection(queues):
     """
     Collects, into a list, dictionaries of connections_config and its workers.
 
-    This function makes an association between some configurarion and the
+    This function makes an association between some configuration and the
     workers it uses.
-    What the return may looks like:
+    What the return may look like:
 
         workers_collection = [
             {
@@ -86,7 +86,7 @@ def collect_workers_by_connection(queues):
 def get_all_workers_by_configuration(config, workers_collections):
     """
     Gets from a worker_collection the worker group associated to a given
-    configuration
+    connection configuration.
     """
     c = filter_connection_params(config)
     for collection in workers_collections:

--- a/django_rq/workers.py
+++ b/django_rq/workers.py
@@ -1,10 +1,10 @@
 from rq import Worker
 from rq.utils import import_attribute
 
-from django.conf import settings as global_settings
+from django.conf import settings
 from django.utils import six
 
-from . import settings
+from .jobs import get_job_class
 from .queues import filter_connection_params, get_connection, get_queues
 
 
@@ -15,7 +15,9 @@ def get_exception_handlers():
         'EXCEPTION_HANDLERS': ['path.to.handler'],
     }
     """
-    return [import_attribute(path) for path in settings.EXCEPTION_HANDLERS]
+    from .settings import EXCEPTION_HANDLERS
+
+    return [import_attribute(path) for path in EXCEPTION_HANDLERS]
 
 
 def get_worker_class(worker_class=None):
@@ -24,8 +26,9 @@ def get_worker_class(worker_class=None):
     If `worker_class` is not None, it is used as an override (can be
     python import path as string).
     """
+    RQ = getattr(settings, 'RQ', {})
+
     if worker_class is None:
-        RQ = getattr(global_settings, 'RQ', {})
         worker_class = Worker
         if 'WORKER_CLASS' in RQ:
             worker_class = RQ.get('WORKER_CLASS')
@@ -39,11 +42,18 @@ def get_worker(*queue_names, **kwargs):
     """
     Returns a RQ worker for all queues or specified ones.
     """
-    queues = get_queues(*queue_names)
+    job_class = get_job_class(kwargs.pop('job_class', None))
+    queue_class = kwargs.pop('queue_class', None)
+    queues = get_queues(*queue_names, **{'job_class': job_class,
+                                         'queue_class': queue_class})
+    # normalize queue_class to what get_queues returns
+    queue_class = queues[0].__class__
     worker_class = get_worker_class(kwargs.pop('worker_class', None))
     return worker_class(queues,
                         connection=queues[0].connection,
                         exception_handlers=get_exception_handlers() or None,
+                        job_class=job_class,
+                        queue_class=queue_class,
                         **kwargs)
 
 


### PR DESCRIPTION
What has been changed:
- Added `RQ.WORKER_CLASS` setting to complement `RQ.QUEUE_CLASS`;
- Changed rqworker management command to use defaults via `get_worker_class`/`get_queue_class` instead of defining it's own;
- in queues.py `get_queue` and `get_queue_by_index` now have `**kwargs` to allow passing any additional kwargs to queue class constructor;
- in worker.py add `get_worker_class` and use it in other functions;
- isort in all changed files.