### PR TITLE
Ability to load SENTRY_DSN for rqworker from Django settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -271,7 +271,13 @@ Additionaly, these statistics are also accessible from  the command line.
 
 Configuring Sentry
 -------------------
-Use ``sentry-dsn`` parameter when running rqworker. ``./manage.py rqworker --sentry-dsn=https://*****@sentry.io/222222``
+The ``SENTRY_DSN`` value from ``settings.py`` is used by default:
+
+``SENTRY_DSN = 'https://*****@sentry.io/222222'``
+
+Also you can specify ``sentry-dsn`` parameter when running rqworker:
+
+``./manage.py rqworker --sentry-dsn=https://*****@sentry.io/222222``
 
 Configuring Logging
 -------------------

--- a/django_rq/management/commands/rqworker.py
+++ b/django_rq/management/commands/rqworker.py
@@ -7,6 +7,7 @@ from redis.exceptions import ConnectionError
 from rq import use_connection
 from rq.utils import ColorizingStreamHandler
 
+from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db import connections
 from django.utils.version import get_version
@@ -67,7 +68,7 @@ class Command(BaseCommand):
         if pid:
             with open(os.path.expanduser(pid), "w") as fp:
                 fp.write(str(os.getpid()))
-        sentry_dsn = options.get('sentry-dsn')
+        sentry_dsn = options.get('sentry-dsn') or getattr(settings, 'SENTRY_DSN', None)
         try:
             # Instantiate a worker
             worker_kwargs = {


### PR DESCRIPTION
I really needed this feature since I'm deploying with dokku and I don't want to store DSN in ini files.
I use environment variables and load them into settings instead. So getting DSN from settings is essential to me.

This is how it's done in https://github.com/rq/rq/blob/master/rq/cli/cli.py#L192