### PR TITLE
Added support for using redis sentinels.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,13 @@ Installation
             'PASSWORD': 'some-password',
             'DEFAULT_TIMEOUT': 360,
         },
+        'with-sentinel': {
+           'SENTINELS': [('localhost', 26736), ('localhost', 26737)],
+           'MASTER_NAME': 'redismaster',
+           'DB': 0,
+           'PASSWORD': 'secret',
+           'SOCKET_TIMEOUT': None,
+        },
         'high': {
             'URL': os.getenv('REDISTOGO_URL', 'redis://localhost:6379/0'), # If you're on Heroku
             'DEFAULT_TIMEOUT': 500,

--- a/django_rq/test_settings.py
+++ b/django_rq/test_settings.py
@@ -106,6 +106,13 @@ RQ_QUEUES = {
         'PORT': 1,
         'DB': 1,
     },
+    'sentinel': {
+        'SENTINELS': [(REDIS_HOST, 26736), (REDIS_HOST, 26737)],
+        'MASTER_NAME': 'testmaster',
+        'DB': 1,
+        'PASSWORD': 'secret',
+        'SOCKET_TIMEOUT': 10,
+    },
     'test1': {
         'HOST': REDIS_HOST,
         'PORT': 1,

--- a/django_rq/utils.py
+++ b/django_rq/utils.py
@@ -28,11 +28,9 @@ def get_statistics():
         else:
             oldest_job_timestamp = "-"
 
-        # parse_class is not needed and not JSON serializable
-        try:
-            del(connection_kwargs['parser_class'])
-        except KeyError:
-            pass
+        # parse_class and connection_pool are not needed and not JSON serializable
+        connection_kwargs.pop('parser_class', None)
+        connection_kwargs.pop('connection_pool', None)
 
         queue_data = {
             'name': queue.name,

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='django-rq',
-    version='1.0.0',
+    version='1.0.2',
     author='Selwin Ong',
     author_email='selwin.ong@gmail.com',
     packages=['django_rq'],


### PR DESCRIPTION
The idea here is to be able to specify in settings a list of sentinels from which the connection to master will be obtained. It seems to be working fine for me, but I may have missed something. Can you please have a look @selwin ?