### PR TITLE
Removed fixed table width.

### DIFF
--- a/django_rq/templates/django_rq/index.html
+++ b/django_rq/templates/django_rq/index.html
@@ -1,25 +1,24 @@
 {% extends "admin/index.html" %}
 
-{% block sidebar %}
-    
-
+{% block extrastyle %}
     {{ block.super }}
+    <style>#django-rq table {width: 100%;}</style>
+{% endblock %}
 
-    <div id = 'django-rq' style = "float: left">
+{% block sidebar %}
+    {{ block.super }}
+    <div id="django-rq">
         <div class="module">
-            <table style="width: 498px">
+            <table>
                 <caption>Django RQ</caption>
                 <tbody>
                     <tr>
                         <th>
-                            <a href = "{% url 'rq_home' %}">
-                                Queues
-                            </a>
+                            <a href = "{% url 'rq_home' %}">Queues</a>
                         </th>
                     </tr>
                 </tbody>
             </table>
         </div>
     </div>
-
 {% endblock %}


### PR DESCRIPTION
Noticed a minor styling issue in the Django RQ admin section. The table appears to be set to a fixed width of 498px, this commit aims to resolve the issue by setting the width to 100%.

**Bug:** _Width set to 498px._
<img width="617" alt="screen shot 2018-04-20 at 21 47 19" src="https://user-images.githubusercontent.com/12101684/39073080-792ca344-44e4-11e8-8689-af956364e591.png">

**Fix:** _Width set to 100%._
<img width="617" alt="screen shot 2018-04-20 at 21 47 37" src="https://user-images.githubusercontent.com/12101684/39073091-80aa6bec-44e4-11e8-8f5c-31cb6e89fa7f.png">