### PR TITLE
In README.rst change the use of url() for Django >= 2.0 to path().

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ Installation
 
     # For Django >= 2.0
     urlpatterns += [
-        url(r'^django-rq/', (urlpatterns, '', 'django_rq'))
+        path('django-rq/', include('django_rq.urls'))
     ]
 
 =====


### PR DESCRIPTION
Change README.rst to use path() instead of url() in the urls.py section to make it more Django 2.0 