### PR TITLE
Rename `async` to `is_async` to support Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7-dev"
 
 env:
   - DJANGO=2.0.6
@@ -17,6 +18,14 @@ matrix:
   exclude:
     - python: "2.7"
       env: DJANGO=2.0.6
+    - python: "3.7-dev"
+      env: DJANGO=1.9.9
+    - python: "3.7-dev"
+      env: DJANGO=1.8.18
+    - python: "3.7-dev"
+      env: DJANGO=1.10.8
+    - python: "3.7-dev"
+      env: DJANGO=1.11.13
 
 install:
   - pip install Django==$DJANGO times docutils pygments

--- a/README.rst
+++ b/README.rst
@@ -107,11 +107,11 @@ Putting jobs in the queue
     queue.enqueue(func, foo, bar=baz)
 
 In addition to ``name`` argument, ``get_queue`` also accepts ``default_timeout``,
-``async``, ``autocommit`` and ``queue_class`` arguments. For example:
+``is_async``, ``autocommit`` and ``queue_class`` arguments. For example:
 
 .. code-block:: python
 
-    queue = django_rq.get_queue('default', autocommit=True, async=True, default_timeout=360)
+    queue = django_rq.get_queue('default', autocommit=True, is_async=True, default_timeout=360)
     queue.enqueue(func, foo, bar=baz)
 
 * ``get_connection`` - accepts a single queue name argument (defaults to "default")
@@ -429,7 +429,7 @@ configuration in your settings file:
         for queueConfig in RQ_QUEUES.itervalues():
             queueConfig['ASYNC'] = False
 
-Note that setting the ``async`` parameter explicitly when calling ``get_queue``
+Note that setting the ``is_async`` parameter explicitly when calling ``get_queue``
 will override this setting.
 
 =============

--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -146,7 +146,7 @@ def get_queue(name='default', default_timeout=None, is_async=None,
     """
     from .settings import QUEUES
 
-    if 'async' in kwargs and kwargs['async'] is not None:
+    if kwargs.get('async') is not None:
         is_async = kwargs['async']
         warnings.warn('The `async` keyword is deprecated. Use `is_async` instead', DeprecationWarning)
 

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -300,7 +300,14 @@ class QueuesTest(TestCase):
         self.assertTrue(default_queue._is_async)
 
         # Make sure is_async override works
-        default_queue_async = get_queue('default', is_async=False)
+        default_queue_is_async = get_queue('default', is_async=False)
+        self.assertFalse(default_queue_is_async._is_async)
+
+        # Make sure old keyword argument 'async' works for backwards
+        # compatibility with code expecting older versions of rq or django-rq.
+        # Note 'async' is a reserved keyword in Python >= 3.7.
+        kwargs = {'async': False}
+        default_queue_async = get_queue('default', **kwargs)
         self.assertFalse(default_queue_async._is_async)
 
         # Make sure is_async setting works

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -295,17 +295,17 @@ class QueuesTest(TestCase):
         """
         Checks whether asynchronous settings work
         """
-        # Make sure async is not set by default
+        # Make sure is_async is not set by default
         default_queue = get_queue('default')
-        self.assertTrue(default_queue._async)
+        self.assertTrue(default_queue._is_async)
 
-        # Make sure async override works
-        default_queue_async = get_queue('default', async=False)
-        self.assertFalse(default_queue_async._async)
+        # Make sure is_async override works
+        default_queue_async = get_queue('default', is_async=False)
+        self.assertFalse(default_queue_async._is_async)
 
-        # Make sure async setting works
+        # Make sure is_async setting works
         async_queue = get_queue('async')
-        self.assertFalse(async_queue._async)
+        self.assertFalse(async_queue._is_async)
 
     @override_settings(RQ={'AUTOCOMMIT': False})
     def test_autocommit(self):

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     package_data={'': ['README.rst']},
-    install_requires=['django>=1.8.0', 'rq>=0.5.5'],
+    install_requires=['django>=1.8.0', 'rq>=0.12'],
     extras_require = {
         'Sentry':  ['raven>=6.1.0'],
         'testing': ['mock>=2.0.0'],
@@ -34,6 +34,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ]


### PR DESCRIPTION
Note that the new version of the dependency rq also did the same rename
for the same reason.

The variable `_async` was also renamed to `_is_async`.

Test in Python 3.7 and mark 3.7 as supported.

Fixes #295