### PR TITLE
Fix how django-rq connects to Sentinel's

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,11 +48,14 @@ Installation
             'DEFAULT_TIMEOUT': 360,
         },
         'with-sentinel': {
-           'SENTINELS': [('localhost', 26736), ('localhost', 26737)],
-           'MASTER_NAME': 'redismaster',
-           'DB': 0,
-           'PASSWORD': 'secret',
-           'SOCKET_TIMEOUT': None,
+            'SENTINELS': [('localhost', 26736), ('localhost', 26737)],
+            'MASTER_NAME': 'redismaster',
+            'DB': 0,
+            'PASSWORD': 'secret',
+            'SOCKET_TIMEOUT': None,
+            'CONNECTION_KWARGS': {
+                'socket_connect_timeout': 0.3
+            },
         },
         'high': {
             'URL': os.getenv('REDISTOGO_URL', 'redis://localhost:6379/0'), # If you're on Heroku

--- a/django_rq/tests/settings.py
+++ b/django_rq/tests/settings.py
@@ -112,6 +112,7 @@ RQ_QUEUES = {
         'DB': 1,
         'PASSWORD': 'secret',
         'SOCKET_TIMEOUT': 10,
+        'CONNECTION_KWARGS': {},
     },
     'test1': {
         'HOST': REDIS_HOST,


### PR DESCRIPTION
* fixes #302 
* added support to pass additional connection kwargs to Sentinel
