### PR TITLE
provide connection as keyword argument for get_queue method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,12 +110,25 @@ Putting jobs in the queue
     queue.enqueue(func, foo, bar=baz)
 
 In addition to ``name`` argument, ``get_queue`` also accepts ``default_timeout``,
-``is_async``, ``autocommit`` and ``queue_class`` arguments. For example:
+``is_async``, ``autocommit``, ``connection`` and ``queue_class`` arguments. For example:
 
 .. code-block:: python
 
     queue = django_rq.get_queue('default', autocommit=True, is_async=True, default_timeout=360)
     queue.enqueue(func, foo, bar=baz)
+
+You can provide your own singleton Redis connection object to this function so that it will not
+create a new connection object for each queue definition. This will help you limit
+number of connections to Redis server. For example:
+
+.. code-block:: python
+
+    import django_rq
+    import redis
+    redis_cursor = redis.StrictRedis(host='', port='', db='', password='')
+    high_queue = django_rq.get('high', connection=redis_cursor)
+    low_queue = django_rq.get('low', connection=redis_cursor)
+
 
 * ``get_connection`` - accepts a single queue name argument (defaults to "default")
   and returns a connection to the queue's `Redis`_ server:

--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -145,7 +145,7 @@ def get_connection_by_index(index):
 
 
 def get_queue(name='default', default_timeout=None, is_async=None,
-              autocommit=None, queue_class=None, job_class=None, **kwargs):
+              autocommit=None, connection=None, queue_class=None, job_class=None, **kwargs):
     """
     Returns an rq Queue using parameters defined in ``RQ_QUEUES``
     """
@@ -163,9 +163,11 @@ def get_queue(name='default', default_timeout=None, is_async=None,
 
     if default_timeout is None:
         default_timeout = QUEUES[name].get('DEFAULT_TIMEOUT')
+    if connection is None:
+        connection = get_connection(name)
     queue_class = get_queue_class(QUEUES[name], queue_class)
     return queue_class(name, default_timeout=default_timeout,
-                       connection=get_connection(name), is_async=is_async,
+                       connection=connection, is_async=is_async,
                        job_class=job_class, autocommit=autocommit, **kwargs)
 
 


### PR DESCRIPTION
this will allow you to provide your own redis connection object instead of creating one internally. 


This is done because every time we create a queue, it ends up creating a new connection object which in turn causes too many connections in redis. 