### PR TITLE
add argument to disable sentry integration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -308,10 +308,11 @@ Also you can specify ``sentry-dsn`` parameter when running rqworker:
 
 ``./manage.py rqworker --sentry-dsn=https://*****@sentry.io/222222``
 
-If your project use ``sentry-sdk``, the DSN is not compatible with the sentry integration
-used inside RQ.
 
-In that case you can disable sentry integration by specifying ``--disable-sentry-integration``.
+**Disable RQ sentry plugin**
+
+If your project use ``sentry-sdk``, the DSN is not compatible with RQ's sentry plugin (based on raven).
+In that case you have to disable the sentry plugin by setting `--sentry-dsn=""`.
 
 Configuring Logging
 -------------------

--- a/README.rst
+++ b/README.rst
@@ -308,6 +308,11 @@ Also you can specify ``sentry-dsn`` parameter when running rqworker:
 
 ``./manage.py rqworker --sentry-dsn=https://*****@sentry.io/222222``
 
+If your project use ``sentry-sdk``, the DSN is not compatible with the sentry integration
+used inside RQ.
+
+In that case you can disable sentry integration by specifying ``--disable-sentry-integration``.
+
 Configuring Logging
 -------------------
 

--- a/django_rq/management/commands/rqworker.py
+++ b/django_rq/management/commands/rqworker.py
@@ -47,6 +47,8 @@ class Command(BaseCommand):
                             help='Default worker timeout to be used')
         parser.add_argument('--sentry-dsn', action='store', default=None, dest='sentry-dsn',
                             help='Report exceptions to this Sentry DSN')
+        parser.add_argument('--disable-sentry-integration', action='store_true', dest='disable-sentry',
+                            help='Disable sentry integration. Useful if `sentry-sdk` is used')
 
         if LooseVersion(get_version()) >= LooseVersion('1.10'):
             parser.add_argument('args', nargs='*', type=str,
@@ -86,7 +88,7 @@ class Command(BaseCommand):
             # Close any opened DB connection before any fork
             reset_db_connections()
 
-            if sentry_dsn:
+            if not options.get('disable-sentry', False) and sentry_dsn:
                 try:
                     from raven import Client
                     from raven.transport.http import HTTPTransport


### PR DESCRIPTION
allow disabling sentry integration in the case where the project use sentry-sdk as `SENTRY_DSN` is not compatible between `sentry_sdk` and `raven` (missing secret key, a.k.a. password)