### PR TITLE
Scheduler now respects default timeout and result_ttl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
       env: DJANGO=1.11.16
 
 install:
-  - pip install Django==$DJANGO times docutils pygments
+  - pip install Django==$DJANGO times docutils pygments rq-scheduler
   - python setup.py install
   - pip install codecov
 

--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -270,13 +270,41 @@ instance instead of a ``Queue`` instance.
 try:
     from rq_scheduler import Scheduler
 
-    def get_scheduler(name='default', interval=60):
+    class DjangoScheduler(Scheduler):
+        """
+        Use settings ``DEFAULT_RESULT_TTL`` from ``RQ``
+        and ``DEFAULT_TIMEOUT`` from ``RQ_QUEUES`` if configured.
+        """
+        def _create_job(self, *args, **kwargs):
+            from .settings import QUEUES
+
+            if kwargs.get('timeout') is None:
+                queue_name = kwargs.get('queue_name') or self.queue_name
+                kwargs['timeout'] = QUEUES[queue_name].get('DEFAULT_TIMEOUT')
+
+            if kwargs.get('result_ttl') is None:
+                kwargs['result_ttl'] = getattr(settings, 'RQ', {}).get('DEFAULT_RESULT_TTL')
+
+            return super(DjangoScheduler, self)._create_job(*args, **kwargs)
+
+
+    def get_scheduler(name='default', queue=None, interval=60):
         """
         Returns an RQ Scheduler instance using parameters defined in
         ``RQ_QUEUES``
         """
-        return Scheduler(name, interval=interval,
-                         connection=get_connection(name))
+        RQ = getattr(settings, 'RQ', {})
+        scheduler_class = RQ.get('SCHEDULER_CLASS', DjangoScheduler)
+        
+        if isinstance(scheduler_class, six.string_types):
+            scheduler_class = import_attribute(scheduler_class)
+
+        if queue is None:
+            queue = get_queue(name)
+
+        return scheduler_class(queue_name=name, interval=interval,
+                               queue=queue, job_class=queue.job_class,
+                               connection=get_connection(name))
 except ImportError:
     def get_scheduler(*args, **kwargs):
         raise ImproperlyConfigured('rq_scheduler not installed')

--- a/django_rq/tests/fixtures.py
+++ b/django_rq/tests/fixtures.py
@@ -17,5 +17,14 @@ class DummyWorker(Worker):
     pass
 
 
+try:
+    from rq_scheduler import Scheduler
+
+    class DummyScheduler(Scheduler):
+        pass
+except ImportError:
+    pass
+
+
 def access_self():
     return get_current_job().id

--- a/django_rq/tests/settings.py
+++ b/django_rq/tests/settings.py
@@ -157,6 +157,12 @@ RQ_QUEUES = {
         'PORT': 6379,
         'DB': 0,
     },
+    'test_scheduler': {
+        'HOST': REDIS_HOST,
+        'PORT': 6379,
+        'DB': 0,
+        'DEFAULT_TIMEOUT': 400,
+    },
 }
 RQ = {
     'AUTOCOMMIT': False,

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -568,6 +568,30 @@ class SchedulerTest(TestCase):
             call_command('rqscheduler', verbosity=verbosity)
             setup_loghandlers_mock.assert_called_once_with(expected_level[verbosity])
 
+    @override_settings(RQ={'AUTOCOMMIT': True, 'DEFAULT_TIMEOUT': 5432})
+    @skipIf(RQ_SCHEDULER_INSTALLED is False, 'RQ Scheduler not installed')
+    def test_scheduler_default_timeout(self):
+        """
+        Ensure scheduler respects DEFAULT_RESULT_TTL value for `result_ttl` param.
+        """
+        scheduler = get_scheduler('test')
+        job = scheduler.enqueue_at(datetime.datetime.now() + datetime.timedelta(days=1), divide, 1, 1)
+        self.assertTrue(job in scheduler.get_jobs())
+        self.assertEqual(job.timeout, 5432)
+        job.delete()
+
+    @override_settings(RQ={'AUTOCOMMIT': True, 'DEFAULT_RESULT_TTL': 5432})
+    @skipIf(RQ_SCHEDULER_INSTALLED is False, 'RQ Scheduler not installed')
+    def test_scheduler_default_result_ttl(self):
+        """
+        Ensure scheduler respects DEFAULT_RESULT_TTL value for `result_ttl` param.
+        """
+        scheduler = get_scheduler('test')
+        job = scheduler.enqueue_at(datetime.datetime.now() + datetime.timedelta(days=1), divide, 1, 1)
+        self.assertTrue(job in scheduler.get_jobs())
+        self.assertEqual(job.result_ttl, 5432)
+        job.delete()
+
 
 class RedisCacheTest(TestCase):
 

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -1,3 +1,4 @@
+import datetime
 import time
 from unittest import skipIf
 from uuid import uuid4
@@ -34,6 +35,7 @@ from django_rq.workers import get_worker, get_worker_class
 try:
     from rq_scheduler import Scheduler
     from ..queues import get_scheduler
+    from django_rq.tests.fixtures import DummyScheduler
     RQ_SCHEDULER_INSTALLED = True
 except ImportError:
     RQ_SCHEDULER_INSTALLED = False
@@ -568,16 +570,25 @@ class SchedulerTest(TestCase):
             call_command('rqscheduler', verbosity=verbosity)
             setup_loghandlers_mock.assert_called_once_with(expected_level[verbosity])
 
-    @override_settings(RQ={'AUTOCOMMIT': True, 'DEFAULT_TIMEOUT': 5432})
+    @override_settings(RQ={'SCHEDULER_CLASS': 'django_rq.tests.fixtures.DummyScheduler'})
+    @skipIf(RQ_SCHEDULER_INSTALLED is False, 'RQ Scheduler not installed')
+    def test_scheduler_default_timeout(self):
+        """
+        Scheduler class customization.
+        """
+        scheduler = get_scheduler('default')
+        self.assertIsInstance(scheduler, DummyScheduler)        
+
+    @override_settings(RQ={'AUTOCOMMIT': True})
     @skipIf(RQ_SCHEDULER_INSTALLED is False, 'RQ Scheduler not installed')
     def test_scheduler_default_timeout(self):
         """
         Ensure scheduler respects DEFAULT_RESULT_TTL value for `result_ttl` param.
         """
-        scheduler = get_scheduler('test')
+        scheduler = get_scheduler('test_scheduler')
         job = scheduler.enqueue_at(datetime.datetime.now() + datetime.timedelta(days=1), divide, 1, 1)
         self.assertTrue(job in scheduler.get_jobs())
-        self.assertEqual(job.timeout, 5432)
+        self.assertEqual(job.timeout, 400)
         job.delete()
 
     @override_settings(RQ={'AUTOCOMMIT': True, 'DEFAULT_RESULT_TTL': 5432})
@@ -586,7 +597,7 @@ class SchedulerTest(TestCase):
         """
         Ensure scheduler respects DEFAULT_RESULT_TTL value for `result_ttl` param.
         """
-        scheduler = get_scheduler('test')
+        scheduler = get_scheduler('test_scheduler')
         job = scheduler.enqueue_at(datetime.datetime.now() + datetime.timedelta(days=1), divide, 1, 1)
         self.assertTrue(job in scheduler.get_jobs())
         self.assertEqual(job.result_ttl, 5432)


### PR DESCRIPTION
As per subject, solves #292.

Thanks for the awesome work!