### PR TITLE
Remove redundant sentry_dsn config line

### DIFF
--- a/django_rq/management/commands/rqworker.py
+++ b/django_rq/management/commands/rqworker.py
@@ -71,7 +71,6 @@ class Command(BaseCommand):
             level = 'INFO'
         setup_loghandlers(level)
 
-        sentry_dsn = options.get('sentry-dsn') or getattr(settings, 'SENTRY_DSN', None)
         try:
             # Instantiate a worker
             worker_kwargs = {

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -266,7 +266,25 @@ class QueuesTest(TestCase):
         queue_names = ['django_rq_test']
         call_command('rqworker', *queue_names, burst=True,
                      sentry_dsn='https://1@sentry.io/1')
+
         self.assertEqual(mocked.call_count, 1)
+
+    @mock.patch('rq.contrib.sentry.register_sentry')
+    def test_sentry_dsn_setting(self, mocked):
+        queue_names = ['django_rq_test']
+        with self.settings(SENTRY_DSN='https://1@sentry.io/1'):
+            call_command('rqworker', *queue_names, burst=True)
+
+            self.assertEqual(mocked.call_count, 1)
+
+    @mock.patch('rq.contrib.sentry.register_sentry')
+    def test_sentry_dsn_setting_override(self, mocked):
+        queue_names = ['django_rq_test']
+        with self.settings(SENTRY_DSN='https://1@sentry.io/1'):
+            call_command('rqworker', *queue_names, burst=True,
+                         sentry_dsn='')
+
+            self.assertEqual(mocked.call_count, 0)
 
     def test_get_unique_connection_configs(self):
         connection_params_1 = {


### PR DESCRIPTION
In our local environment we use the config var "SENTRY_SDK" for our actual sentry_sdk package variable in settings.

With that variable set I was unable to set --sentry-sdk="" with the environment variable still set because the line deleted would override the option passed in and thus rqworker would crash until we changed our config variable to something other than SENTRY_SDK.