### PR TITLE
Added explicit dependency on `sentry-sdk`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     package_data={'': ['README.rst']},
-    install_requires=['django>=1.8.0', 'rq>=1.0', 'redis>=3'],
+    install_requires=['django>=1.8.0', 'rq>=1.0', 'redis>=3', 'sentry-sdk>=0.7.13'],
     extras_require={
         'Sentry':  ['raven>=6.1.0'],
         'testing': ['mock>=2.0.0'],


### PR DESCRIPTION
This is in relation to a submitted issue, #339 