### PR TITLE
Bug Fix: Fix NOAUTH when using Sentinel with Password

### DIFF
--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -109,7 +109,7 @@ def get_redis_connection(config, use_strict_redis=False):
             'socket_timeout': config.get('SOCKET_TIMEOUT'),
         }
         sentinel_kwargs.update(config.get('CONNECTION_KWARGS', {}))
-        sentinel = Sentinel(config['SENTINELS'], **sentinel_kwargs)
+        sentinel = Sentinel(config['SENTINELS'], sentinel_kwargs=sentinel_kwargs, **sentinel_kwargs)
         return sentinel.master_for(
             service_name=config['MASTER_NAME'], redis_class=redis_cls,
         )


### PR DESCRIPTION
Currently when using Sentinel the password from the config is not passed through to the Sentinel class which results in a NOAUTH when connecting.

This patch passes through the same `PASSWORD` from the config through to both the Sentinel and the Master. This may not be what you want but it will solve the problem if both passwords are the same.