### PR TITLE
support Django 3.0 (remove dependency on django.utils.six + fix load admin_static)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - "3.7"
 
 env:
+  - DJANGO=3.0
   - DJANGO=2.2
   - DJANGO=2.1
   - DJANGO=2.0.8
@@ -18,6 +19,10 @@ env:
 
 matrix:
   exclude:
+    - python: "3.5"
+      env: DJANGO=3.0
+    - python: "2.7"
+      env: DJANGO=3.0
     - python: "2.7"
       env: DJANGO=2.2
     - python: "2.7"

--- a/django_rq/decorators.py
+++ b/django_rq/decorators.py
@@ -1,9 +1,14 @@
 from rq.decorators import job as _rq_job
 
 from django.conf import settings
-from django.utils import six
 
 from .queues import get_queue
+
+try:
+    from django.utils.six import string_types
+except ImportError:
+    string_types = str
+
 
 
 def job(func_or_queue, connection=None, *args, **kwargs):
@@ -24,7 +29,7 @@ def job(func_or_queue, connection=None, *args, **kwargs):
         func = None
         queue = func_or_queue
 
-    if isinstance(queue, six.string_types):
+    if isinstance(queue, string_types):
         try:
             queue = get_queue(queue)
             if connection is None:

--- a/django_rq/jobs.py
+++ b/django_rq/jobs.py
@@ -2,7 +2,11 @@ from rq.job import Job
 from rq.utils import import_attribute
 
 from django.conf import settings
-from django.utils import six
+
+try:
+    from django.utils.six import string_types
+except ImportError:
+    string_types = str
 
 
 def get_job_class(job_class=None):
@@ -16,6 +20,6 @@ def get_job_class(job_class=None):
     if job_class is None:
         job_class = RQ.get('JOB_CLASS', Job)
 
-    if isinstance(job_class, six.string_types):
+    if isinstance(job_class, string_types):
         job_class = import_attribute(job_class)
     return job_class

--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -8,10 +8,14 @@ from rq.utils import import_attribute
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.utils import six
 from django_rq import thread_queue
 
 from .jobs import get_job_class
+
+try:
+    from django.utils.six import string_types
+except ImportError:
+    string_types = str
 
 
 def get_commit_mode():
@@ -45,7 +49,7 @@ def get_queue_class(config=None, queue_class=None):
         if config:
             queue_class = config.get('QUEUE_CLASS', queue_class)
 
-    if isinstance(queue_class, six.string_types):
+    if isinstance(queue_class, string_types):
         queue_class = import_attribute(queue_class)
     return queue_class
 
@@ -276,7 +280,7 @@ try:
         RQ = getattr(settings, 'RQ', {})
         scheduler_class = RQ.get('SCHEDULER_CLASS', DjangoScheduler)
 
-        if isinstance(scheduler_class, six.string_types):
+        if isinstance(scheduler_class, string_types):
             scheduler_class = import_attribute(scheduler_class)
 
         if queue is None:

--- a/django_rq/templates/django_rq/job_detail.html
+++ b/django_rq/templates/django_rq/job_detail.html
@@ -1,6 +1,6 @@
 {% extends "admin/base_site.html" %}
 
-{% load admin_static django_rq %}
+{% load static django_rq %}
 
 {% block title %}Job {{ job.id }} {{ block.super }}{% endblock %}
 

--- a/django_rq/templates/django_rq/jobs.html
+++ b/django_rq/templates/django_rq/jobs.html
@@ -1,6 +1,6 @@
 {% extends "admin/base_site.html" %}
 
-{% load admin_static jquery_path django_rq %}
+{% load static jquery_path django_rq %}
 
 {% block title %}{{ job_status }} Jobs in {{ queue.name }} {{ block.super }}{% endblock %}
 

--- a/django_rq/templates/django_rq/worker_details.html
+++ b/django_rq/templates/django_rq/worker_details.html
@@ -1,6 +1,6 @@
 {% extends "admin/base_site.html" %}
 
-{% load admin_static django_rq %}
+{% load static django_rq %}
 
 {% block extrastyle %}
     {{ block.super }}

--- a/django_rq/templates/django_rq/workers.html
+++ b/django_rq/templates/django_rq/workers.html
@@ -1,6 +1,6 @@
 {% extends "admin/base_site.html" %}
 
-{% load admin_static jquery_path django_rq l10n %}
+{% load static jquery_path django_rq l10n %}
 
 {% block title %}Workers in {{ queue.name }} {{ block.super }}{% endblock %}
 

--- a/django_rq/workers.py
+++ b/django_rq/workers.py
@@ -2,10 +2,14 @@ from rq import Worker
 from rq.utils import import_attribute
 
 from django.conf import settings
-from django.utils import six
 
 from .jobs import get_job_class
 from .queues import filter_connection_params, get_connection, get_queues
+
+try:
+    from django.utils.six import string_types
+except ImportError:
+    string_types = str
 
 
 def get_exception_handlers():
@@ -33,7 +37,7 @@ def get_worker_class(worker_class=None):
         if 'WORKER_CLASS' in RQ:
             worker_class = RQ.get('WORKER_CLASS')
 
-    if isinstance(worker_class, six.string_types):
+    if isinstance(worker_class, string_types):
         worker_class = import_attribute(worker_class)
     return worker_class
 

--- a/integration_test/_tests.py
+++ b/integration_test/_tests.py
@@ -14,7 +14,11 @@ import unittest
 import psycopg2
 import requests
 from django.conf import settings
-from django.utils.six.moves.urllib.parse import urlunsplit
+
+try:
+    from django.utils.six.moves.urllib.parse import urlunsplit
+except ImportError:
+    from urllib.parse import urlunsplit
 
 DJANGO_SETTINGS_MODULE = "integration_test.settings"
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", DJANGO_SETTINGS_MODULE)


### PR DESCRIPTION
Fixes #382 without pulling in `six` explicitly.

Probably needed for #383.
