### PR TITLE
Honor logging level set by --verbosity

### DIFF
--- a/django_rq/management/commands/rqworker.py
+++ b/django_rq/management/commands/rqworker.py
@@ -96,7 +96,7 @@ class Command(BaseCommand):
                     self.stdout.write(self.style.ERROR("Please install sentry-sdk using `pip install sentry-sdk`"))
                     sys.exit(1)
 
-            w.work(burst=options.get('burst', False))
+            w.work(burst=options.get('burst', False), logging_level=level)
         except ConnectionError as e:
             print(e)
             sys.exit(1)


### PR DESCRIPTION
I discovered that verbosity parameter is not honored because [worker gets called with default info parameter](https://github.com/rq/rq/blob/master/rq/worker.py#L443).