### PR TITLE
Stats for scheduled jobs

### DIFF
--- a/django_rq/templates/django_rq/jobs.html
+++ b/django_rq/templates/django_rq/jobs.html
@@ -70,6 +70,9 @@
                             </th>
                             <th><div class = 'text'><span>ID</span></div></th>
                             <th><div class = 'text'><span>Created</span></div></th>
+                            {% if job_status == 'Scheduled' %}
+                                <th><div class = 'text'><span>Scheduled</span></div></th>
+                            {% endif %}
                             <th><div class = 'text'><span>Enqueued</span></div></th>
                             <th><div class = 'text'><span>Status</span></div></th>
                             <th><div class = 'text'><span>Callable</span></div></th>
@@ -93,6 +96,13 @@
                                         {{ job.created_at|to_localtime|date:"Y-m-d, H:i:s" }}
                                     {% endif %}
                                 </td>
+                                {% if job_status == 'Scheduled' %}
+                                    <td>
+                                        {% if job.scheduled_at %}
+                                            {{ job.scheduled_at|to_localtime|date:"Y-m-d, H:i:s" }}
+                                        {% endif %}
+                                    </td>
+                                {% endif %}
                                 <td>
                                     {% if job.enqueued_at %}
                                         {{ job.enqueued_at|to_localtime|date:"Y-m-d, H:i:s" }}

--- a/django_rq/templates/django_rq/jobs.html
+++ b/django_rq/templates/django_rq/jobs.html
@@ -82,37 +82,39 @@
                     </thead>
                     <tbody>
                         {% for job in jobs %}
-                            <tr class = "{% cycle 'row1' 'row2' %}">
-                                <td class="action-checkbox">
-                                    <input class="action-select" name="_selected_action" type="checkbox" value="{{ job.id }}">
-                                </td>
-                                <th>
-                                    <a href = "{% url 'rq_job_detail' queue_index job.id %}">
-                                        {{ job.id }}
-                                    </a>
-                                </th>
-                                <td>
-                                    {% if job.created_at %}
-                                        {{ job.created_at|to_localtime|date:"Y-m-d, H:i:s" }}
-                                    {% endif %}
-                                </td>
-                                {% if job_status == 'Scheduled' %}
+                            {% if job is not None %}
+                                <tr class = "{% cycle 'row1' 'row2' %}">
+                                    <td class="action-checkbox">
+                                        <input class="action-select" name="_selected_action" type="checkbox" value="{{ job.id }}">
+                                    </td>
+                                    <th>
+                                        <a href = "{% url 'rq_job_detail' queue_index job.id %}">
+                                            {{ job.id }}
+                                        </a>
+                                    </th>
                                     <td>
-                                        {% if job.scheduled_at %}
-                                            {{ job.scheduled_at|to_localtime|date:"Y-m-d, H:i:s" }}
+                                        {% if job.created_at %}
+                                            {{ job.created_at|to_localtime|date:"Y-m-d, H:i:s" }}
                                         {% endif %}
                                     </td>
-                                {% endif %}
-                                <td>
-                                    {% if job.enqueued_at %}
-                                        {{ job.enqueued_at|to_localtime|date:"Y-m-d, H:i:s" }}
+                                    {% if job_status == 'Scheduled' %}
+                                        <td>
+                                            {% if job.scheduled_at %}
+                                                {{ job.scheduled_at|to_localtime|date:"Y-m-d, H:i:s" }}
+                                            {% endif %}
+                                        </td>
                                     {% endif %}
-                                </td>
-                                <td>{{ job.get_status }}</td>
-                                <td>{{ job|show_func_name }}</td>
-                                {% block extra_columns_values %}
-                                {% endblock extra_columns_values %}
-                            </tr>
+                                    <td>
+                                        {% if job.enqueued_at %}
+                                            {{ job.enqueued_at|to_localtime|date:"Y-m-d, H:i:s" }}
+                                        {% endif %}
+                                    </td>
+                                    <td>{{ job.get_status }}</td>
+                                    <td>{{ job|show_func_name }}</td>
+                                    {% block extra_columns_values %}
+                                    {% endblock extra_columns_values %}
+                                </tr>
+                            {% endif %}
                         {% endfor %}
                     </tbody>
                 </table>

--- a/django_rq/templates/django_rq/stats.html
+++ b/django_rq/templates/django_rq/stats.html
@@ -31,7 +31,7 @@
                     <th>Deferred Jobs</th>
                     <th>Finished Jobs</th>
                     <th>Failed Jobs</th>
-                    <th>Scheduled jobs</th>
+                    <th>Scheduled Jobs</th>
                     <th>Workers</th>
                     <th>Host</th>
                     <th>Port</th>

--- a/django_rq/templates/django_rq/stats.html
+++ b/django_rq/templates/django_rq/stats.html
@@ -31,6 +31,7 @@
                     <th>Deferred Jobs</th>
                     <th>Finished Jobs</th>
                     <th>Failed Jobs</th>
+                    <th>Scheduled jobs</th>
                     <th>Workers</th>
                     <th>Host</th>
                     <th>Port</th>
@@ -70,6 +71,11 @@
                               <a href = "{% url 'rq_failed_jobs' queue.index %}">
                                   {{ queue.failed_jobs }}
                               </a>
+                        </th>
+                        <th>
+                            <a href = "{% url 'rq_scheduled_jobs' queue.index %}">
+                                {{ queue.scheduled_jobs }}
+                            </a>
                         </th>
                         <th><a href = "{% url 'rq_workers' queue.index %}">
                                 {{ queue.workers }}

--- a/django_rq/tests/test_views.py
+++ b/django_rq/tests/test_views.py
@@ -8,8 +8,13 @@ from django.test.client import Client
 from django.urls import reverse
 
 from rq.job import Job, JobStatus
-from rq.registry import (DeferredJobRegistry, FailedJobRegistry,
-                         FinishedJobRegistry, StartedJobRegistry)
+from rq.registry import (
+    DeferredJobRegistry, 
+    FailedJobRegistry,
+    FinishedJobRegistry, 
+    ScheduledJobRegistry, 
+    StartedJobRegistry
+)
 
 from django_rq import get_queue
 from django_rq.workers import get_worker
@@ -264,6 +269,23 @@ class ViewTest(TestCase):
             reverse('rq_scheduled_jobs', args=[queue_index])
         )
         self.assertEqual(response.context['jobs'], [job])
+
+    def test_scheduled_jobs_registry_removal(self):
+        """Ensure that non existing job is being deleted from registry by view"""
+        queue = get_queue('django_rq_test')
+        queue_index = get_queue_index('django_rq_test')
+
+        registry = ScheduledJobRegistry(queue.name, queue.connection)
+        job = queue.enqueue_at(datetime.now(), access_self)
+        self.assertEqual(len(registry), 1)
+
+        queue.connection.delete(job.key)
+        response = self.client.get(
+            reverse('rq_scheduled_jobs', args=[queue_index])
+        )
+        self.assertEqual(response.context['jobs'], [None])
+
+        self.assertEqual(len(registry), 0)
 
     def test_started_jobs(self):
         """Ensure that active jobs page works properly."""

--- a/django_rq/tests/test_views.py
+++ b/django_rq/tests/test_views.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import datetime
 from unittest.mock import patch, PropertyMock
 
 from django.contrib.auth.models import User
@@ -244,6 +245,23 @@ class ViewTest(TestCase):
         registry.add(job, 2)
         response = self.client.get(
             reverse('rq_failed_jobs', args=[queue_index])
+        )
+        self.assertEqual(response.context['jobs'], [job])
+
+    def test_scheduled_jobs(self):
+        """Ensure that scheduled jobs page works properly."""
+        queue = get_queue('django_rq_test')
+        queue_index = get_queue_index('django_rq_test')
+
+        # Test that page doesn't fail when ScheduledJobRegistry is empty
+        response = self.client.get(
+            reverse('rq_scheduled_jobs', args=[queue_index])
+        )
+        self.assertEqual(response.status_code, 200)
+
+        job = queue.enqueue_at(datetime.now(), access_self)
+        response = self.client.get(
+            reverse('rq_scheduled_jobs', args=[queue_index])
         )
         self.assertEqual(response.context['jobs'], [job])
 

--- a/django_rq/urls.py
+++ b/django_rq/urls.py
@@ -18,6 +18,8 @@ urlpatterns = [
             views.finished_jobs, name='rq_finished_jobs'),
     re_path(r'^queues/(?P<queue_index>[\d]+)/failed/$',
             views.failed_jobs, name='rq_failed_jobs'),
+    re_path(r'^queues/(?P<queue_index>[\d]+)/scheduled/$',
+            views.scheduled_jobs, name='rq_scheduled_jobs'),
     re_path(r'^queues/(?P<queue_index>[\d]+)/started/$',
             views.started_jobs, name='rq_started_jobs'),
     re_path(r'^queues/(?P<queue_index>[\d]+)/deferred/$',

--- a/django_rq/utils.py
+++ b/django_rq/utils.py
@@ -1,5 +1,11 @@
-from rq.registry import (DeferredJobRegistry, FailedJobRegistry,
-                         FinishedJobRegistry, StartedJobRegistry, clean_registries)
+from rq.registry import (
+    DeferredJobRegistry, 
+    FailedJobRegistry, 
+    FinishedJobRegistry, 
+    ScheduledJobRegistry,
+    StartedJobRegistry, 
+    clean_registries
+)
 from rq.worker import Worker
 from rq.worker_registration import clean_worker_registry
 
@@ -51,10 +57,12 @@ def get_statistics(run_maintenance_tasks=False):
         started_job_registry = StartedJobRegistry(queue.name, connection)
         deferred_job_registry = DeferredJobRegistry(queue.name, connection)
         failed_job_registry = FailedJobRegistry(queue.name, connection)
+        scheduled_job_registry = ScheduledJobRegistry(queue.name, connection)
         queue_data['finished_jobs'] = len(finished_job_registry)
         queue_data['started_jobs'] = len(started_job_registry)
         queue_data['deferred_jobs'] = len(deferred_job_registry)
         queue_data['failed_jobs'] = len(failed_job_registry)
+        queue_data['scheduled_jobs'] = len(scheduled_job_registry)
 
         queues.append(queue_data)
     return {'queues': queues}

--- a/django_rq/views.py
+++ b/django_rq/views.py
@@ -168,8 +168,11 @@ def scheduled_jobs(request, queue_index):
         job_ids = registry.get_job_ids(offset, offset + items_per_page - 1)
 
         jobs = Job.fetch_many(job_ids, connection=queue.connection)
-        for job in jobs:
-            job.scheduled_at = registry.get_scheduled_time(job)
+        for i, job in enumerate(jobs):
+            if job is None:
+                registry.remove(job_ids[i])
+            else:
+                job.scheduled_at = registry.get_scheduled_time(job)            
 
     else:
         page_range = []

--- a/django_rq/views.py
+++ b/django_rq/views.py
@@ -11,8 +11,13 @@ from redis.exceptions import ResponseError
 from rq import requeue_job
 from rq.exceptions import NoSuchJobError, UnpickleError
 from rq.job import Job, JobStatus
-from rq.registry import (DeferredJobRegistry, FailedJobRegistry,
-                         FinishedJobRegistry, StartedJobRegistry)
+from rq.registry import (
+    DeferredJobRegistry, 
+    FailedJobRegistry, 
+    FinishedJobRegistry, 
+    ScheduledJobRegistry,
+    StartedJobRegistry, 
+)
 from rq.worker import Worker
 
 from .queues import get_queue_by_index
@@ -140,6 +145,47 @@ def failed_jobs(request, queue_index):
         'page': page,
         'page_range': page_range,
         'job_status': 'Failed',
+    }
+    return render(request, 'django_rq/jobs.html', context_data)
+
+
+@staff_member_required
+def scheduled_jobs(request, queue_index):
+    queue_index = int(queue_index)
+    queue = get_queue_by_index(queue_index)
+
+    registry = ScheduledJobRegistry(queue.name, queue.connection)
+
+    items_per_page = 100
+    num_jobs = len(registry)
+    page = int(request.GET.get('page', 1))
+    jobs = []
+
+    if num_jobs > 0:
+        last_page = int(ceil(num_jobs / items_per_page))
+        page_range = range(1, last_page + 1)
+        offset = items_per_page * (page - 1)
+        job_ids = registry.get_job_ids(offset, offset + items_per_page - 1)
+
+        for job_id in job_ids:
+            try:
+                job = Job.fetch(job_id, connection=queue.connection)
+                job.scheduled_at = registry.get_scheduled_time(job)
+                jobs.append(job)
+            except NoSuchJobError:
+                pass
+
+    else:
+        page_range = []
+
+    context_data = {
+        'queue': queue,
+        'queue_index': queue_index,
+        'jobs': jobs,
+        'num_jobs': num_jobs,
+        'page': page,
+        'page_range': page_range,
+        'job_status': 'Scheduled',
     }
     return render(request, 'django_rq/jobs.html', context_data)
 

--- a/django_rq/views.py
+++ b/django_rq/views.py
@@ -167,13 +167,9 @@ def scheduled_jobs(request, queue_index):
         offset = items_per_page * (page - 1)
         job_ids = registry.get_job_ids(offset, offset + items_per_page - 1)
 
-        for job_id in job_ids:
-            try:
-                job = Job.fetch(job_id, connection=queue.connection)
-                job.scheduled_at = registry.get_scheduled_time(job)
-                jobs.append(job)
-            except NoSuchJobError:
-                pass
+        jobs = Job.fetch_many(job_ids, connection=queue.connection)
+        for job in jobs:
+            job.scheduled_at = registry.get_scheduled_time(job)
 
     else:
         page_range = []


### PR DESCRIPTION
Starting with 1.2.0 rq  supports job scheduling without additional requirements, so it would be nice to support stats for scheduled jobs.

This line https://github.com/rq/django-rq/pull/400/files#diff-51cc121b676f5b91f7ee8499cc586a1dR173 may not be the best idea, but I don't see a clearer way of adding this attribute without additional changes in rq.
