### PR TITLE
docs: Fix simple typo, requeueing -> requeuing

### DIFF
--- a/django_rq/tests/test_views.py
+++ b/django_rq/tests/test_views.py
@@ -85,7 +85,7 @@ class ViewTest(TestCase):
 
     def test_requeue_all(self):
         """
-        Ensure that requeueing all failed job work properly
+        Ensure that requeuing all failed job work properly
         """
         def failing_job():
             raise ValueError
@@ -105,7 +105,7 @@ class ViewTest(TestCase):
 
     def test_requeue_all_if_deleted_job(self):
         """
-        Ensure that requeueing all failed job work properly
+        Ensure that requeuing all failed job work properly
         """
         def failing_job():
             raise ValueError


### PR DESCRIPTION
There is a small typo in django_rq/tests/test_views.py.

Should read `requeuing` rather than `requeueing`.

