### PR TITLE
Fix ignored DEFAULT_RESULT_TTL

### DIFF
--- a/django_rq/decorators.py
+++ b/django_rq/decorators.py
@@ -33,7 +33,7 @@ def job(func_or_queue, connection=None, *args, **kwargs):
 
     RQ = getattr(settings, 'RQ', {})
     default_result_ttl = RQ.get('DEFAULT_RESULT_TTL')
-    if default_result_ttl:
+    if default_result_ttl is not None:
         kwargs.setdefault('result_ttl', default_result_ttl)
 
     decorator = _rq_job(queue, connection=connection, *args, **kwargs)

--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -221,6 +221,11 @@ def enqueue(func, *args, **kwargs):
     from django_rq import enqueue
     enqueue(func, *args, **kwargs)
     """
+    RQ = getattr(settings, 'RQ', {})
+    default_result_ttl = RQ.get('DEFAULT_RESULT_TTL')
+    if default_result_ttl is not None:
+        kwargs.setdefault('result_ttl', default_result_ttl)
+
     return get_queue().enqueue(func, *args, **kwargs)
 
 

--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -221,11 +221,6 @@ def enqueue(func, *args, **kwargs):
     from django_rq import enqueue
     enqueue(func, *args, **kwargs)
     """
-    RQ = getattr(settings, 'RQ', {})
-    default_result_ttl = RQ.get('DEFAULT_RESULT_TTL')
-    if default_result_ttl is not None:
-        kwargs.setdefault('result_ttl', default_result_ttl)
-
     return get_queue().enqueue(func, *args, **kwargs)
 
 

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -440,6 +440,14 @@ class DecoratorTest(TestCase):
         self.assertEqual(result.result_ttl, 5432)
         result.delete()
 
+    @override_settings(RQ={'AUTOCOMMIT': True, 'DEFAULT_RESULT_TTL': 0})
+    def test_job_decorator_result_ttl_zero(self):
+        @job
+        def test():
+            pass
+        result = test.delay()
+        self.assertEqual(result.result_ttl, 0)
+        result.delete()
 
 @override_settings(RQ={'AUTOCOMMIT': True})
 class WorkersTest(TestCase):


### PR DESCRIPTION
This library has a very useful setting to set a default `result_tt`, but it is not always respected.

Two issues with the `DEFAULT_RESULT_TTL` setting should be fixed with this PR:
1. `DEFAULT_RESULT_TTL` is ignored in the `job` decorator when it is set to zero.
2. `DEFAULT_RESULT_TTL` is completely ignored in the `enqueue` method.