### PR TITLE
Update rqworker command Sentry configuration (alternative version)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ django_rq.egg-info/
 *.rdb
 # pycharm
 .idea
+Pipfile.lock

--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ django-redis = {editable = true,git = "https://github.com/niwinz/django-redis.gi
 docutils = "*"
 pygments = "*"
 rq-scheduler = "*"
+coverage = "*"
 
 [packages]
 django-rq = {editable = true,path = "."}

--- a/README.rst
+++ b/README.rst
@@ -331,7 +331,7 @@ setting the following Sentry options:
     {
         'debug': options.get('sentry_debug'),
         'ca_certs': options.get('sentry_ca_certs'),
-        'integrations': [RqIntegration(), DjangoIntegration()]
+        'integrations': [RedisIntegration(), RqIntegration(), DjangoIntegration()]
     }
 
 

--- a/README.rst
+++ b/README.rst
@@ -315,13 +315,24 @@ Additionally, these statistics are also accessible from  the command line.
 
 Configuring Sentry
 -------------------
-Django-RQ >= 2.0 uses ``sentry-sdk`` instead of the deprecated ``raven`` library. The ``SENTRY_DSN`` value from ``settings.py`` is used by default:
+Django-RQ >= 2.0 uses ``sentry-sdk`` instead of the deprecated ``raven`` library. Sentry
+should be configured within the Django ``settings.py`` as described in the `Sentry docs <https://docs.sentry.io/platforms/python/django/>`__.
 
-``SENTRY_DSN = 'https://*****@sentry.io/222222'``
-
-Also you can specify ``sentry-dsn`` parameter when running rqworker:
+You can override the default Django Sentry configuration when running the ``rqworker`` command
+by passing the ``sentry-dsn`` option:
 
 ``./manage.py rqworker --sentry-dsn=https://*****@sentry.io/222222``
+
+This will override any existing Django configuration and reinitialise Sentry,
+setting the following Sentry options:
+
+.. code-block:: python
+
+    {
+        'debug': options.get('sentry_debug'),
+        'ca_certs': options.get('sentry_ca_certs'),
+        'integrations': [RqIntegration(), DjangoIntegration()]
+    }
 
 
 Configuring Logging

--- a/django_rq/management/commands/rqworker.py
+++ b/django_rq/management/commands/rqworker.py
@@ -38,6 +38,7 @@ def configure_sentry(sentry_dsn, **options):
         'debug': options.get('sentry_debug', False),
         'ca_certs': options.get('sentry_ca_certs', None),
         'integrations': [
+            sentry_sdk.integrations.redis.RedisIntegration(),
             sentry_sdk.integrations.rq.RqIntegration(),
             sentry_sdk.integrations.django.DjangoIntegration()
         ]

--- a/django_rq/management/commands/rqworker.py
+++ b/django_rq/management/commands/rqworker.py
@@ -139,5 +139,5 @@ class Command(BaseCommand):
 
             w.work(burst=options.get('burst', False), with_scheduler=options.get('with_scheduler', False), logging_level=level)
         except ConnectionError as e:
-            self.stdout.write(self.style.ERROR(e))
+            self.stderr.write(e)
             sys.exit(1)

--- a/django_rq/management/commands/rqworker.py
+++ b/django_rq/management/commands/rqworker.py
@@ -32,11 +32,12 @@ def configure_sentry(sentry_dsn, **options):
     Raises ImportError if the sentry_sdk is not available.
 
     """
-    opts = sentry_options()
-    sentry_debug = options.get('sentry-debug') or getattr(settings, 'SENTRY_DEBUG', False)
+    # remove 'integrations' as this clashes with the register_sentry function
+    opts = {k:v for k,v in sentry_options().items() if k != 'integrations'}
+    sentry_debug = options.get('sentry_debug') or getattr(settings, 'SENTRY_DEBUG', False)
     if sentry_debug:
         opts['debug'] = sentry_debug
-    sentry_ca_certs = options.get('sentry-ca-certs') or getattr(settings, 'SENTRY_CA_CERTS', None)
+    sentry_ca_certs = options.get('sentry_ca_certs') or getattr(settings, 'SENTRY_CA_CERTS', None)
     if sentry_ca_certs:
         opts['ca_certs'] = sentry_ca_certs
 
@@ -86,11 +87,11 @@ class Command(BaseCommand):
         parser.add_argument('--worker-ttl', action='store', type=int,
                             dest='worker_ttl', default=420,
                             help='Default worker timeout to be used')
-        parser.add_argument('--sentry-dsn', action='store', default=None, dest='sentry-dsn',
+        parser.add_argument('--sentry-dsn', action='store', default=None, dest='sentry_dsn',
                             help='Report exceptions to this Sentry DSN')
-        parser.add_argument('--sentry-ca-certs', action='store', default=None, dest='sentry-ca-certs',
+        parser.add_argument('--sentry-ca-certs', action='store', default=None, dest='sentry_ca_certs',
                             help='A path to an alternative CA bundle file in PEM-format')
-        parser.add_argument('--sentry-debug', action='store', default=False, dest='sentry-debug',
+        parser.add_argument('--sentry-debug', action='store', default=False, dest='sentry_debug',
                             help='Turns debug mode on or off.')
 
         if LooseVersion(get_version()) >= LooseVersion('1.10'):
@@ -103,7 +104,7 @@ class Command(BaseCommand):
             with open(os.path.expanduser(pid), "w") as fp:
                 fp.write(str(os.getpid()))
 
-        sentry_dsn = options.get('sentry-dsn')
+        sentry_dsn = options.pop('sentry_dsn')
         if sentry_dsn is None:
             sentry_dsn = getattr(settings, 'SENTRY_DSN', None)
 

--- a/django_rq/management/commands/rqworker.py
+++ b/django_rq/management/commands/rqworker.py
@@ -103,7 +103,9 @@ class Command(BaseCommand):
             with open(os.path.expanduser(pid), "w") as fp:
                 fp.write(str(os.getpid()))
 
-        sentry_dsn = options.pop('sentry-dsn') or getattr(settings, 'SENTRY_DSN', None)
+        sentry_dsn = options.get('sentry-dsn')
+        if sentry_dsn is None:
+            sentry_dsn = getattr(settings, 'SENTRY_DSN', None)
 
         # Verbosity is defined by default in BaseCommand for all commands
         verbosity = options.get('verbosity')

--- a/django_rq/management/commands/rqworker.py
+++ b/django_rq/management/commands/rqworker.py
@@ -59,6 +59,14 @@ class Command(BaseCommand):
             parser.add_argument('args', nargs='*', type=str,
                                 help='The queues to work on, separated by space')
 
+    def _try_import_sentry_sdk(self):
+        """Try to import sentry_sdk - extracted to facilitate testing."""
+        try:
+            import sentry_sdk
+        except ImportError:
+            self.stderr.write("Please install sentry-sdk using `pip install sentry-sdk`")
+            sys.exit(1)
+
     def sentry_options(self, **options):
         """
         Return options to be used to configue Sentry.
@@ -68,11 +76,7 @@ class Command(BaseCommand):
         to the command. The options passed in to the command take precedence.
 
         """
-        try:
-            import sentry_sdk
-        except ImportError:
-            self.stdout.write(self.style.ERROR("Please install sentry-sdk using `pip install sentry-sdk`"))
-            sys.exit(1)
+        self._try_import_sentry_sdk()
 
         if sentry_sdk.Hub.current.client:
             sentry_options = sentry_sdk.Hub.current.client.options

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -308,7 +308,7 @@ class QueuesTest(TestCase):
             call_command('rqworker', *queue_names, burst=True,
                          sentry_dsn='')
 
-        mocked.assert_called_once_with('https://1@sentry.io/1')
+        self.assertEqual(mocked.call_count, 0)
 
     @mock.patch('rq.contrib.sentry.register_sentry')
     def test_sentry_dsn_certs(self, mocked):
@@ -322,9 +322,8 @@ class QueuesTest(TestCase):
     def test_sentry_dsn_debug(self, mocked):
         queue_names = ['django_rq_test']
         call_command('rqworker', *queue_names, burst=True,
-                        sentry_dsn='https://1@sentry.io/1',
-                        sentry_debug=True
-                        )
+                     sentry_dsn='https://1@sentry.io/1',
+                     sentry_debug=True)
         self.assertEqual(mocked.call_count, 1)
         self.assertEqual(mocked.call_args[0][0], 'https://1@sentry.io/1')
         self.assertEqual(mocked.call_args[1]['debug'], True)

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -269,16 +269,19 @@ class QueuesTest(TestCase):
 
     @mock.patch.object(rqworker.Command, '_try_import_sentry_sdk', lambda obj: None)
     @mock.patch('rq.contrib.sentry.register_sentry')
-    def test_sentry_options(self, mocked):
+    def test_sentry_options__no_client(self, mocked):
         rqworker.sentry_sdk = mock.MagicMock()
-        rqworker.sentry_sdk.Hub.current.client = mock.Mock(options={})
+        rqworker.sentry_sdk.Hub.current.client = None
         options = {'sentry-debug': True, 'sentry-ca-certs': '123456'}
-        opts = rqworker.Command().sentry_options(**options)
-        self.assertEqual(opts, {'debug': True, 'ca_certs': '123456'})
+        self.assertEqual(
+            rqworker.Command().sentry_options(**options),
+            {'debug': True, 'ca_certs': '123456'}
+        )
 
     @mock.patch.object(rqworker.Command, '_try_import_sentry_sdk', lambda obj: None)
     @mock.patch('rq.contrib.sentry.register_sentry')
-    def test_sentry_options__no_override(self, mocked):
+    def test_sentry_options(self, mocked):
+        """Test the existing options are maintained."""
         rqworker.sentry_sdk = mock.MagicMock()
         rqworker.sentry_sdk.Hub.current.client = mock.Mock(
             options={'environment': 'dev'}

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -267,6 +267,16 @@ class QueuesTest(TestCase):
             self.assertTrue(job['job'].is_finished)
             self.assertIn(job['job'].id, job['finished_job_registry'].get_job_ids())
 
+    @mock.patch("django_rq.management.commands.rqworker.sys")
+    def test__try_import(self, mock_sys):
+        """Check the sentry_sdk import fails as expected."""
+        # this test is included to get test coverage over the bar.
+        with self.assertRaises(ImportError):
+            import sentry_sdk
+        rqworker.Command()._try_import_sentry_sdk()
+        mock_sys.exit.assert_called_once_with(1)
+
+
     @mock.patch.object(rqworker.Command, '_try_import_sentry_sdk', lambda obj: None)
     @mock.patch('rq.contrib.sentry.register_sentry')
     def test_sentry_options__no_client(self, mocked):

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -285,6 +285,7 @@ class QueuesTest(TestCase):
             ca_certs=None,
             debug=False,
             integrations=[
+                self.mock_sdk.integrations.redis.RedisIntegration(),
                 self.mock_sdk.integrations.rq.RqIntegration(),
                 self.mock_sdk.integrations.django.DjangoIntegration(),
             ]
@@ -298,6 +299,7 @@ class QueuesTest(TestCase):
             ca_certs='/certs',
             debug=True,
             integrations=[
+                self.mock_sdk.integrations.redis.RedisIntegration(),
                 self.mock_sdk.integrations.rq.RqIntegration(),
                 self.mock_sdk.integrations.django.DjangoIntegration(),
             ]
@@ -314,6 +316,7 @@ class QueuesTest(TestCase):
             ca_certs='/certs',
             debug=True,
             integrations=[
+                self.mock_sdk.integrations.redis.RedisIntegration(),
                 self.mock_sdk.integrations.rq.RqIntegration(),
                 self.mock_sdk.integrations.django.DjangoIntegration(),
             ]

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -17,6 +17,7 @@ from rq.worker import Worker
 
 from django_rq.decorators import job
 from django_rq.jobs import get_job_class
+from django_rq.management.commands import rqworker
 from django_rq.queues import (
     get_connection, get_queue, get_queues,
     get_unique_connection_configs, DjangoRQ,
@@ -266,6 +267,7 @@ class QueuesTest(TestCase):
             self.assertTrue(job['job'].is_finished)
             self.assertIn(job['job'].id, job['finished_job_registry'].get_job_ids())
 
+    @mock.patch.object(rqworker.Command, 'sentry_options', lambda obj, **opts: {})
     @mock.patch('rq.contrib.sentry.register_sentry')
     def test_sentry_dsn(self, mocked):
         queue_names = ['django_rq_test']
@@ -274,6 +276,18 @@ class QueuesTest(TestCase):
 
         self.assertEqual(mocked.call_count, 1)
 
+    @mock.patch.object(rqworker.Command, 'sentry_options')
+    @mock.patch('rq.contrib.sentry.register_sentry')
+    def test_sentry_options(self, mocked, mock_options):
+        mock_options.return_value = {'environment': 'dev'}
+        queue_names = ['django_rq_test']
+        call_command('rqworker', *queue_names, burst=True,
+                     sentry_dsn='https://1@sentry.io/1')
+
+        self.assertEqual(mocked.call_count, 1)
+        mocked.assert_called_once_with('https://1@sentry.io/1', environment='dev')
+
+    @mock.patch.object(rqworker.Command, 'sentry_options', lambda obj, **opts: {})
     @mock.patch('rq.contrib.sentry.register_sentry')
     def test_sentry_dsn_setting(self, mocked):
         queue_names = ['django_rq_test']
@@ -282,6 +296,7 @@ class QueuesTest(TestCase):
 
             self.assertEqual(mocked.call_count, 1)
 
+    @mock.patch.object(rqworker.Command, 'sentry_options', lambda obj, **opts: {})
     @mock.patch('rq.contrib.sentry.register_sentry')
     def test_sentry_dsn_setting_override(self, mocked):
         queue_names = ['django_rq_test']
@@ -291,6 +306,7 @@ class QueuesTest(TestCase):
 
             self.assertEqual(mocked.call_count, 0)
 
+    @mock.patch.object(rqworker.Command, 'sentry_options', lambda obj, **opts: {})
     @mock.patch('rq.contrib.sentry.register_sentry')
     def test_sentry_dsn_certs(self, mocked):
         queue_names = ['django_rq_test']
@@ -302,6 +318,7 @@ class QueuesTest(TestCase):
 
             self.assertEqual(mocked.call_count, 1)
 
+    @mock.patch.object(rqworker.Command, 'sentry_options', lambda obj, **opts: {})
     @mock.patch('rq.contrib.sentry.register_sentry')
     def test_sentry_dsn_debug(self, mocked):
         queue_names = ['django_rq_test']

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -286,6 +286,39 @@ class QueuesTest(TestCase):
         self.assertEqual(rqworker.sentry_options(), {})
 
     @mock.patch('rq.contrib.sentry.register_sentry')
+    def test_configure_sentry(self, mocked):
+        rqworker.configure_sentry('sentry_dsn')
+        mocked.assert_called_once_with('sentry_dsn')
+
+    @mock.patch('rq.contrib.sentry.register_sentry')
+    def test_configure_sentry__integrations(self, mocked):
+        """Check that custom 'integrations' are not passed in to Sentry."""
+        self.mock_sdk.Hub.current.client.options = {'integrations': ['foo']}
+        rqworker.configure_sentry('sentry_dsn')
+        mocked.assert_called_once_with('sentry_dsn')
+
+    @mock.patch('rq.contrib.sentry.register_sentry')
+    def test_configure_sentry__integrations_removed(self, mocked):
+        """Check that custom 'integrations' are not passed in to Sentry."""
+        self.mock_sdk.Hub.current.client.options = {'integrations': []}
+        rqworker.configure_sentry('sentry_dsn')
+        mocked.assert_called_once_with('sentry_dsn')
+
+    @mock.patch('rq.contrib.sentry.register_sentry')
+    def test_configure_sentry__debug(self, mocked):
+        """Check that custom 'integrations' are not passed in to Sentry."""
+        self.mock_sdk.Hub.current.client.options = {'debug': False}
+        rqworker.configure_sentry('sentry_dsn', sentry_debug=True)
+        mocked.assert_called_once_with('sentry_dsn', debug=True)
+
+    @mock.patch('rq.contrib.sentry.register_sentry')
+    def test_configure_sentry__ca_certs(self, mocked):
+        """Check that custom 'integrations' are not passed in to Sentry."""
+        self.mock_sdk.Hub.current.client.options = {'ca_certs': None}
+        rqworker.configure_sentry('sentry_dsn', sentry_ca_certs='/path')
+        mocked.assert_called_once_with('sentry_dsn', ca_certs='/path')
+
+    @mock.patch('rq.contrib.sentry.register_sentry')
     def test_sentry_dsn(self, mocked):
         queue_names = ['django_rq_test']
         call_command('rqworker', *queue_names, burst=True,


### PR DESCRIPTION
This is a simpler alternative to #441. Fixes #440 and #427. 

---

This PR changes how the `rqworker` command integrates with Sentry.

At the current time, if you pass in `sentry-dsn`, **or** have `django.conf.settings.SENTRY_DSN` set, then the command will reinitialise Sentry using a limited subset of options, overriding any existing Django setup. The options supported are `debug` and `ca_certs`, and the list of integrations is restricted to `RqIntegration`. 

This PR prevents the possible clash with Django settings by removing the fallback to `SENTRY_DSN`. If you pass `sentry-dsn` to the command, it will use it, and ignore any existing Django settings configuration. If you don't pass it, it will do nothing - i.e. it will rely on any existing Django configuration.

In addition, this does away with the `rq.contrib.sentry.register_sentry` function call in favour of a direct `sentry_sdk.init` call. The RQ function explicitly sets up Sentry with `integrations=[RqIntegration()]`, preventing the use of any other integrations. This makes sense within the context of `rq`, but if you are using `django-rq` then it makes more sense to use `[RedisIntegration(), RqIntegration(), DjangoIntegration()]`.

This PR will be a breaking change for anyone who does not pass `sentry-dsn` to the command, but **does** have `django.conf.settings.SENTRY_DSN` set. This may be a dealbreaker, but that group seems like an edge case?
