### PR TITLE
Allow setting ssl_cert_reqs and username in get_redis_connection

### DIFF
--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -112,7 +112,7 @@ def get_redis_connection(config, use_strict_redis=False):
             service_name=config['MASTER_NAME'], redis_class=redis_cls,
         )
 
-    return redis_cls(host=config['HOST'], port=config['PORT'], db=config['DB'], password=config.get('PASSWORD'), ssl=config.get('SSL', False))
+    return redis_cls(host=config['HOST'], port=config['PORT'], db=config['DB'], password=config.get('PASSWORD'), ssl=config.get('SSL', False), ssl_cert_reqs=config.get('SSL_CERT_REQS', 'required'))
 
 
 def get_connection(name='default', use_strict_redis=False):

--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -112,7 +112,7 @@ def get_redis_connection(config, use_strict_redis=False):
             service_name=config['MASTER_NAME'], redis_class=redis_cls,
         )
 
-    return redis_cls(host=config['HOST'], port=config['PORT'], db=config['DB'], password=config.get('PASSWORD'), ssl=config.get('SSL', False), ssl_cert_reqs=config.get('SSL_CERT_REQS', 'required'))
+    return redis_cls(host=config['HOST'], port=config['PORT'], db=config.get('DB', 0), username=config.get('USERNAME', None), password=config.get('PASSWORD'), ssl=config.get('SSL', False), ssl_cert_reqs=config.get('SSL_CERT_REQS', 'required'))
 
 
 def get_connection(name='default', use_strict_redis=False):


### PR DESCRIPTION
Hi, I'm a bit new to contributing to a project, happy to make changes as suggested.

Context: This was prompted by not being able to connect to Redis on Heroku.
https://help.heroku.com/HC0F8CUS/redis-connection-issues

I needed to be able to set the ssl_cert_reqs.

Also, question: Should we add all the params below instead of a select few?
https://github.com/andymccurdy/redis-py/blob/1a41cfd95a53a95b078084d8627be6b6fba3bb71/redis/client.py#L737-L749

Thanks!