### PR TITLE
removed link to django-suit-rq

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -537,13 +537,6 @@ Commit and re-deploy. Then add your new worker with:
 
     heroku scale worker=1
 
-=======================
-Django Suit Integration
-=======================
-
-You can use `django-suit-rq <https://github.com/gsmke/django-suit-rq>`__ to make your
-admin fit in with the django-suit styles.
-
 =========
 Changelog
 =========


### PR DESCRIPTION
At the bottom of the README was a link to: https://github.com/coremke/django-suit-rq

this project was not updated since 2016.

I guess it makes sense to remove this link from the README