### PR TITLE
Create force_escape template tag to escape text marked as safe

### DIFF
--- a/django_rq/templates/django_rq/job_detail.html
+++ b/django_rq/templates/django_rq/job_detail.html
@@ -128,7 +128,7 @@
                         {% if job.args %}
                           <ul>
                               {% for arg in job.args %}
-                                  <li>{{ arg }}</li>
+                                  <li>{{ arg|force_escape }}</li>
                               {% endfor %}
                           </ul>
                         {% endif %}
@@ -147,7 +147,7 @@
                         {% if job.kwargs %}
                             <ul>
                                 {% for key, value in job.kwargs.items %}
-                                    <li>{{ key }}: {{ value|escape }}</li>
+                                    <li>{{ key }}: {{ value|force_escape }}</li>
                                 {% endfor %}
                             </ul>
                         {% endif %}

--- a/django_rq/templatetags/django_rq.py
+++ b/django_rq/templatetags/django_rq.py
@@ -1,5 +1,6 @@
 from django import template
 from django.utils import timezone
+from django.utils.html import escape
 
 
 register = template.Library()
@@ -21,3 +22,8 @@ def show_func_name(job):
         return job.func_name
     except Exception as e:
         return repr(e)
+
+
+@register.filter
+def force_escape(text):
+    return escape(text)

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase, override_settings
 from django.urls import reverse
-from django.utils.html import SafeString
+from django.utils.safestring import SafeString
 
 from redis.exceptions import ConnectionError
 from rq import get_current_job, Queue

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.core.management import call_command
 from django.test import TestCase, override_settings
 from django.urls import reverse
+from django.utils.html import SafeString
 
 from redis.exceptions import ConnectionError
 from rq import get_current_job, Queue
@@ -26,7 +27,7 @@ from django_rq.queues import (
     get_redis_connection
 )
 from django_rq import thread_queue
-from django_rq.templatetags.django_rq import to_localtime
+from django_rq.templatetags.django_rq import force_escape, to_localtime
 from django_rq.tests.fixtures import DummyJob, DummyQueue, DummyWorker
 from django_rq.utils import get_jobs, get_statistics
 from django_rq.workers import get_worker, get_worker_class
@@ -797,6 +798,25 @@ class TemplateTagTest(TestCase):
 
             self.assertIsNotNone(time.tzinfo)
             self.assertEqual(time.strftime("%z"), '+0700')
+
+    def test_force_escape_safe_string(self):
+        html = "<h1>hello world</h1>"
+        safe_string = SafeString(html)
+
+        escaped_string = force_escape(safe_string)
+        expected = "&lt;h1&gt;hello world&lt;/h1&gt;"
+
+        self.assertEqual(escaped_string, expected)
+
+    def test_force_escape_regular_string(self):
+        html = "hello world"
+        safe_string = SafeString(html)
+
+        escaped_string = force_escape(safe_string)
+        expected = "hello world"
+
+        self.assertEqual(escaped_string, expected)
+
 
 
 class UtilsTest(TestCase):


### PR DESCRIPTION
Hi, this PR tries to solve issue #479 .

A new template tag `force_escape` is created and used in `job_detail.html` to escape `args` and `kwargs` of a job function event if they are `SafeString`