### PR TITLE
[fix] Fixed use of ssl_cert_reqs for non ssl

### DIFF
--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -77,11 +77,17 @@ def get_redis_connection(config, use_strict_redis=False):
     redis_cls = redis.StrictRedis if use_strict_redis else redis.Redis
 
     if 'URL' in config:
-        return redis_cls.from_url(
-            config['URL'], 
-            db=config.get('DB'), 
-            ssl_cert_reqs=config.get('SSL_CERT_REQS', 'required')
-        )
+        if config.get('SSL') or config.get('URL').startswith('rediss://'):
+            return redis_cls.from_url(
+                config['URL'],
+                db=config.get('DB'),
+                ssl_cert_reqs=config.get('SSL_CERT_REQS', 'required'),
+            )
+        else:
+            return redis_cls.from_url(
+                config['URL'],
+                db=config.get('DB'),
+            )
 
     if 'USE_REDIS_CACHE' in config.keys():
 


### PR DESCRIPTION
Based on https://github.com/rq/django-rq/issues/508 fixed the issue
when redis URL given is non-ssl

Just created base PR here with the idea of https://github.com/rq/django-rq/issues/508#issuecomment-971765269.
Should fully fix https://github.com/rq/django-rq/issues/508
