### PR TITLE
Remove job from ScheduledJobRegistry if enqueued manually

### DIFF
--- a/django_rq/views.py
+++ b/django_rq/views.py
@@ -506,6 +506,9 @@ def enqueue_job(request, queue_index, job_id):
         elif job.get_status() == JobStatus.FINISHED:
             registry = FinishedJobRegistry(queue.name, queue.connection)
             registry.remove(job)
+        elif job.get_status() == JobStatus.SCHEDULED:
+            registry = ScheduledJobRegistry(queue.name, queue.connection)
+            registry.remove(job)
 
         messages.info(request, 'You have successfully enqueued %s' % job.id)
         return redirect('rq_job_detail', queue_index, job_id)


### PR DESCRIPTION
When using admin view to manually enqueue a scheduled job, it is not removed from the ScheduledJobRegistry (I think this was missed when implementing the scheduler).