### PR TITLE
Remove usage of deprecated LooseVersion

### DIFF
--- a/django_rq/management/commands/rqenqueue.py
+++ b/django_rq/management/commands/rqenqueue.py
@@ -1,7 +1,4 @@
-from distutils.version import LooseVersion
-
 from django.core.management.base import BaseCommand
-from django.utils.version import get_version
 
 from ... import get_queue
 
@@ -18,9 +15,7 @@ class Command(BaseCommand):
                             help='Specify the queue [default]')
         parser.add_argument('--timeout', '-t', type=int, dest='timeout',
                             help='A timeout in seconds')
-
-        if LooseVersion(get_version()) >= LooseVersion('1.9'):
-            parser.add_argument('args', nargs='*')
+        parser.add_argument('args', nargs='*')
 
     def handle(self, *args, **options):
         """

--- a/django_rq/management/commands/rqscheduler.py
+++ b/django_rq/management/commands/rqscheduler.py
@@ -1,9 +1,7 @@
 import os
-from distutils.version import LooseVersion
 
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.base import BaseCommand
-from django.utils.version import get_version
 
 from ... import get_scheduler
 
@@ -29,9 +27,7 @@ class Command(BaseCommand):
                             queue (in seconds).""")
         parser.add_argument('--queue', dest='queue', default='default',
                             help="Name of the queue used for scheduling.",)
-
-        if LooseVersion(get_version()) >= LooseVersion('1.9'):
-            parser.add_argument('args', nargs='*')
+        parser.add_argument('args', nargs='*')
 
     def handle(self, *args, **options):
         pid = options.get('pid')

--- a/django_rq/management/commands/rqworker.py
+++ b/django_rq/management/commands/rqworker.py
@@ -1,6 +1,5 @@
 import os
 import sys
-from distutils.version import LooseVersion
 
 from redis.exceptions import ConnectionError
 from rq import use_connection
@@ -8,7 +7,6 @@ from rq.logutils import setup_loghandlers
 
 from django.core.management.base import BaseCommand
 from django.db import connections
-from django.utils.version import get_version
 
 from ...workers import get_worker
 
@@ -81,10 +79,8 @@ class Command(BaseCommand):
                             help='A path to an alternative CA bundle file in PEM-format')
         parser.add_argument('--sentry-debug', action='store', default=False, dest='sentry_debug',
                             help='Turns debug mode on or off.')
-
-        if LooseVersion(get_version()) >= LooseVersion('1.10'):
-            parser.add_argument('args', nargs='*', type=str,
-                                help='The queues to work on, separated by space')
+        parser.add_argument('args', nargs='*', type=str,
+                            help='The queues to work on, separated by space')
 
     def handle(self, *args, **options):
         pid = options.get('pid')

--- a/django_rq/templatetags/jquery_path.py
+++ b/django_rq/templatetags/jquery_path.py
@@ -1,20 +1,9 @@
-from distutils.version import LooseVersion
 from django import template
-from django.utils.version import get_version
 
 
 register = template.Library()
 
-if LooseVersion(get_version()) >= LooseVersion('1.9'):
-    JQUERY_PATH = 'admin/js/vendor/jquery/jquery.js'
 
-    # `assignment_tag` is deprecated as of 1.9, `simple_tag` should be used
-    tag_decorator = register.simple_tag
-else:
-    JQUERY_PATH = 'admin/js/jquery.js'
-    tag_decorator = register.assignment_tag
-
-
-@tag_decorator
+@register.simple_tag
 def get_jquery_path():
-    return JQUERY_PATH
+    return 'admin/js/vendor/jquery/jquery.js'


### PR DESCRIPTION
The minimum supported version of Django is now 2.0. All these
checks for 1.9 and 1.10 are no longer needed.