### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -453,7 +453,7 @@ Custom job class should inherit from ``rq.job.Job``. It will be used for all job
 if configured.
 
 Custom worker class should inherit from ``rq.worker.Worker``. It will be used for running
-all workers unless overriden by ``rqworker`` management command ``worker-class`` option.
+all workers unless overridden by ``rqworker`` management command ``worker-class`` option.
 
 Testing Tip
 -----------

--- a/django_rq/tests/test_views.py
+++ b/django_rq/tests/test_views.py
@@ -180,7 +180,7 @@ class ViewTest(TestCase):
             job = queue.enqueue(access_self, depends_on=previous_job)
             previous_job = job
 
-        # This job is deffered
+        # This job is deferred
         last_job = job
         self.assertEqual(last_job.get_status(), JobStatus.DEFERRED)
         self.assertIsNone(last_job.enqueued_at)

--- a/django_rq/thread_queue.py
+++ b/django_rq/thread_queue.py
@@ -7,7 +7,7 @@ _thread_data = threading.local()
 def get_queue():
     """
     Returns a temporary queue to store jobs before they're committed
-    later in the request/responsce cycle. Each job is stored as a tuple
+    later in the request/response cycle. Each job is stored as a tuple
     containing the queue, args and kwargs.
 
     For example, if we call ``queue.enqueue_call(foo, kwargs={'bar': 'baz'})`` during the

--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -1,4 +1,4 @@
-A sample project to test rqworker and site interraction
+A sample project to test rqworker and site interaction
 
 ## Prerequisites
 


### PR DESCRIPTION
There are small typos in:
- README.rst
- django_rq/tests/test_views.py
- django_rq/thread_queue.py
- integration_test/README.md

Fixes:
- Should read `response` rather than `responsce`.
- Should read `overridden` rather than `overriden`.
- Should read `interaction` rather than `interraction`.
- Should read `deferred` rather than `deffered`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md