### PR TITLE
Feature/add scheduler pid info

### DIFF
--- a/django_rq/models.py
+++ b/django_rq/models.py
@@ -13,6 +13,7 @@ if not get_commit_mode():
 class Queue(models.Model):
     """Placeholder model with no database table, but with django admin page
     and contenttype permission"""
+    id = models.AutoField(primary_key=True)
 
     class Meta:
         managed = False  # not in Django's database

--- a/django_rq/models.py
+++ b/django_rq/models.py
@@ -13,8 +13,6 @@ if not get_commit_mode():
 class Queue(models.Model):
     """Placeholder model with no database table, but with django admin page
     and contenttype permission"""
-    id = models.AutoField(primary_key=True)
-
     class Meta:
         managed = False  # not in Django's database
         default_permissions = ()

--- a/django_rq/templates/django_rq/stats.html
+++ b/django_rq/templates/django_rq/stats.html
@@ -85,7 +85,11 @@
                         <td>{{ queue.connection_kwargs.host }}</td>
                         <td>{{ queue.connection_kwargs.port }}</td>
                         <td>{{ queue.connection_kwargs.db }}</td>
+                        {% if queue.scheduler_pid == -1 %}
+                        <td>Unknown</td>
+                        {% else %}
                         <td>{{ queue.scheduler_pid|default_if_none:"Inactive" }}</td>
+                        {% endif %}
                     </tr>
                 {% endfor %}
             </tbody>

--- a/django_rq/templates/django_rq/stats.html
+++ b/django_rq/templates/django_rq/stats.html
@@ -36,7 +36,9 @@
                     <th>Host</th>
                     <th>Port</th>
                     <th>DB</th>
-                    <th>Scheduler PID</th>
+                    {% if queue.scheduler_pid is Not False %}
+                        <th>Scheduler PID</th>
+                    {% endif%}
                 </tr>
             </thead>
             <tbody>
@@ -85,9 +87,7 @@
                         <td>{{ queue.connection_kwargs.host }}</td>
                         <td>{{ queue.connection_kwargs.port }}</td>
                         <td>{{ queue.connection_kwargs.db }}</td>
-                        {% if queue.scheduler_pid == -1 %}
-                        <td>Unknown</td>
-                        {% else %}
+                        {% if queue.scheduler_pid is Not False %}
                         <td>{{ queue.scheduler_pid|default_if_none:"Inactive" }}</td>
                         {% endif %}
                     </tr>

--- a/django_rq/templates/django_rq/stats.html
+++ b/django_rq/templates/django_rq/stats.html
@@ -85,7 +85,7 @@
                         <td>{{ queue.connection_kwargs.host }}</td>
                         <td>{{ queue.connection_kwargs.port }}</td>
                         <td>{{ queue.connection_kwargs.db }}</td>
-                        <td>{{ queue.scheduler_pid|default_if_none:False }}</td>
+                        <td>{{ queue.scheduler_pid|default_if_none:"Inactive" }}</td>
                     </tr>
                 {% endfor %}
             </tbody>

--- a/django_rq/templates/django_rq/stats.html
+++ b/django_rq/templates/django_rq/stats.html
@@ -36,7 +36,7 @@
                     <th>Host</th>
                     <th>Port</th>
                     <th>DB</th>
-                    {% if queue.scheduler_pid is Not False %}
+                    {% if queue.scheduler_pid is not False %}
                         <th>Scheduler PID</th>
                     {% endif%}
                 </tr>
@@ -87,7 +87,7 @@
                         <td>{{ queue.connection_kwargs.host }}</td>
                         <td>{{ queue.connection_kwargs.port }}</td>
                         <td>{{ queue.connection_kwargs.db }}</td>
-                        {% if queue.scheduler_pid is Not False %}
+                        {% if queue.scheduler_pid is not False %}
                         <td>{{ queue.scheduler_pid|default_if_none:"Inactive" }}</td>
                         {% endif %}
                     </tr>

--- a/django_rq/templates/django_rq/stats.html
+++ b/django_rq/templates/django_rq/stats.html
@@ -36,7 +36,7 @@
                     <th>Host</th>
                     <th>Port</th>
                     <th>DB</th>
-                    <th>Sch PID</th>
+                    <th>Scheduler PID</th>
                 </tr>
             </thead>
             <tbody>

--- a/django_rq/templates/django_rq/stats.html
+++ b/django_rq/templates/django_rq/stats.html
@@ -36,6 +36,7 @@
                     <th>Host</th>
                     <th>Port</th>
                     <th>DB</th>
+                    <th>Sch PID</th>
                 </tr>
             </thead>
             <tbody>
@@ -84,6 +85,7 @@
                         <td>{{ queue.connection_kwargs.host }}</td>
                         <td>{{ queue.connection_kwargs.port }}</td>
                         <td>{{ queue.connection_kwargs.db }}</td>
+                        <td>{{ queue.scheduler_pid|default_if_none:False }}</td>
                     </tr>
                 {% endfor %}
             </tbody>

--- a/django_rq/tests/settings.py
+++ b/django_rq/tests/settings.py
@@ -148,6 +148,30 @@ RQ_QUEUES = {
         'PORT': 6379,
         'DB': 0,
     },
+    'scheduler_scheduler_active_test': {
+        'HOST': REDIS_HOST,
+        'PORT': 6379,
+        'DB': 0,
+        'ASYNC': False,
+    },
+    'scheduler_scheduler_inactive_test': {
+        'HOST': REDIS_HOST,
+        'PORT': 6379,
+        'DB': 0,
+        'ASYNC': False,
+    },
+    'worker_scheduler_active_test': {
+        'HOST': REDIS_HOST,
+        'PORT': 6379,
+        'DB': 0,
+        'ASYNC': False,
+    },
+    'worker_scheduler_inactive_test': {
+        'HOST': REDIS_HOST,
+        'PORT': 6379,
+        'DB': 0,
+        'ASYNC': False,
+    },
     'django-redis': {
         'USE_REDIS_CACHE': 'default',
     },

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -808,8 +808,6 @@ class TemplateTagTest(TestCase):
         self.assertEqual(escaped_string, expected)
 
 
-def mocked_relase_locks():
-    print("Mock Release Locks")
 class SchedulerPIDTest(TestCase):
     @skipIf(RQ_SCHEDULER_INSTALLED is False, 'RQ Scheduler not installed')
     def test_scheduler_scheduler_pid_active(self):

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -826,7 +826,7 @@ class SchedulerPIDTest(TestCase):
             new_callable=PropertyMock(return_value=queues)):
             scheduler = get_scheduler(test_queue)
             scheduler.register_birth()
-            self.assertIsNotNone(get_scheduler_pid(get_queue(scheduler.queue_name)))
+            self.assertIs(get_scheduler_pid(get_queue(scheduler.queue_name)), False)
             scheduler.register_death()
     
     @skipIf(RQ_SCHEDULER_INSTALLED is False, 'RQ Scheduler not installed')
@@ -847,7 +847,7 @@ class SchedulerPIDTest(TestCase):
             scheduler = get_scheduler(test_queue)
             scheduler.remove_lock()
             scheduler.register_death()  # will mark the scheduler as death so get_scheduler_pid will return None
-            self.assertIsNone(get_scheduler_pid(get_queue(scheduler.queue_name)))
+            self.assertIs(get_scheduler_pid(get_queue(scheduler.queue_name)), False)
 
     @skipIf(RQ_SCHEDULER_INSTALLED is True, 'RQ Scheduler installed (no worker--with-scheduler)')
     def test_worker_scheduler_pid_active(self):
@@ -867,7 +867,10 @@ class SchedulerPIDTest(TestCase):
                 queue = get_queue(test_queue)
                 worker = get_worker(test_queue, name=uuid4().hex)
                 worker.work(with_scheduler=True, burst=True)  # force the worker to acquire a scheduler lock
-                self.assertIsNotNone(get_scheduler_pid(queue))
+                pid = get_scheduler_pid(queue)
+                self.assertIsNotNone(pid)
+                self.assertIsNot(pid, False)
+                self.assertIsInstance(pid, int)
 
     @skipIf(RQ_SCHEDULER_INSTALLED is True, 'RQ Scheduler installed (no worker--with-scheduler)')
     def test_worker_scheduler_pid_inactive(self):

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -32,7 +32,7 @@ from django_rq.queues import (
 from django_rq import thread_queue
 from django_rq.templatetags.django_rq import force_escape, to_localtime
 from django_rq.tests.fixtures import DummyJob, DummyQueue, DummyWorker
-from django_rq.utils import get_jobs, get_statistics
+from django_rq.utils import get_jobs, get_statistics, get_scheduler_pid
 from django_rq.workers import get_worker, get_worker_class
 
 try:
@@ -807,6 +807,78 @@ class TemplateTagTest(TestCase):
 
         self.assertEqual(escaped_string, expected)
 
+
+
+class SchedulerPIDTest(TestCase):
+
+    @skipIf(RQ_SCHEDULER_INSTALLED is False, 'RQ Scheduler not installed')
+    def test_scheduler_scheduler_pid_active(self):
+        queues = [{
+            'connection_config': {
+                'DB': 0,
+                'HOST': 'localhost',
+                'PORT': 6379,
+            },
+            'name': 'scheduler_scheduler_active'
+        }]        
+        with patch('django_rq.utils.QUEUES_LIST',
+            new_callable=PropertyMock(return_value=queues)):
+            get_scheduler('scheduler_scheduler_active')
+            self.assertIsNotNone(get_scheduler_pid(queue=None))  # No queue object needed
+
+    @skipIf(RQ_SCHEDULER_INSTALLED is False, 'RQ Scheduler not installed')
+    def test_scheduler_scheduler_pid_inactive(self):
+        queues = [{
+            'connection_config': {
+                'DB': 0,
+                'HOST': 'localhost',
+                'PORT': 6379,
+            },
+            'name': 'scheduler_scheduler_inactive'
+        }]        
+        with patch('django_rq.utils.QUEUES_LIST',
+            new_callable=PropertyMock(return_value=queues)):
+            scheduler = get_scheduler('scheduler_scheduler_inactive')
+            scheduler.register_death()  # will mark the scheduler as death so get_scheduler_pid will return None
+            self.assertIsNone(get_scheduler_pid(queue=None))  # No queue object needed
+
+    @skipIf(RQ_SCHEDULER_INSTALLED is True, 'RQ Scheduler installed (no worker--with-scheduler)')
+    def test_worker_scheduler_pid_active(self):
+        '''The worker works as scheduler too if RQ Scheduler not installed, and the pid scheduler_pid is correct'''
+        queues = [{
+            'connection_config': {
+                'DB': 0,
+                'HOST': 'localhost',
+                'PORT': 6379,
+            },
+            'name': 'worker_scheduler_active'
+        }]        
+        with patch('django_rq.utils.QUEUES_LIST',
+            new_callable=PropertyMock(return_value=queues)):
+            worker = get_worker('worker_scheduler_active', name=uuid4().hex)
+            worker.register_birth()
+            worker.work(with_scheduler=True)  # force the worker to acquire a scheduler lock
+            self.assertIsNotNone(get_scheduler_pid(worker.queues[0]))
+            worker.register_death()
+
+    @skipIf(RQ_SCHEDULER_INSTALLED is True, 'RQ Scheduler installed (no worker--with-scheduler)')
+    def test_worker_scheduler_pid_inactive(self):
+        '''The worker works as scheduler too if RQ Scheduler not installed, and the pid scheduler_pid is correct'''
+        queues = [{
+            'connection_config': {
+                'DB': 0,
+                'HOST': 'localhost',
+                'PORT': 6379,
+            },
+            'name': 'worker_scheduler_inactive'
+        }]        
+        with patch('django_rq.utils.QUEUES_LIST',
+            new_callable=PropertyMock(return_value=queues)):
+            worker = get_worker('worker_scheduler_inactive', name=uuid4().hex)
+            worker.register_birth()
+            worker.work(with_scheduler=False)  # worker will not acquire lock, scheduler_pid should return None
+            self.assertIsNone(get_scheduler_pid(worker.queues[0]))
+            worker.register_death()
 
 class UtilsTest(TestCase):
     def test_get_statistics(self):

--- a/django_rq/utils.py
+++ b/django_rq/utils.py
@@ -18,20 +18,15 @@ from django.core.exceptions import ImproperlyConfigured
 
 def get_scheduler_pid(queue):
     '''Checks whether there's a scheduler-lock on a particular queue, and returns the PID.
-        It works by first checking if there's an RQ-Scheduler active.
+        It Only works with RQ's Built-in RQScheduler.
+        When RQ-Scheduler is available returns False 
         If not, it checks the RQ's RQScheduler for a scheduler lock in the desired queue
         Note: result might have some delay (1-15 minutes) but it helps visualizing whether the setup is working correcly
     '''
     try:
-        # first try to use rq-scheduler
+        # first try get the rq-scheduler
         scheduler = get_scheduler(queue.name)  # should fail if rq_scheduler not present
-        # currently, scheduler_lock_key is not used but, just in case, try
-        lock_key = scheduler.scheduler_lock_key
-        conn = scheduler.connection
-        if conn.get(lock_key):
-            return scheduler.pid
-        else:
-            return -1  # -1 Would be rendered as "Unknown"
+        return False  # Not possible to give useful information without creating a performance issue (redis.keys())
     except ImproperlyConfigured:
         from rq.scheduler import RQScheduler
         # When a scheduler acquires a lock it adds an expiring key: (e.g: rq:scheduler-lock:<queue.name>)

--- a/django_rq/utils.py
+++ b/django_rq/utils.py
@@ -37,7 +37,7 @@ def scheduler_pid(queue):
         # When a scheduler acquires a lock it adds an expiring key: (e.g: rq:scheduler-lock:<queue.name>)
         # If the key exists
         if pid := queue.connection.get(RQScheduler.get_locking_key(queue.name)):
-            return pid
+            return pid.decode()
     except Exception as e:
         return str(e)  # Temporary
     return None

--- a/django_rq/utils.py
+++ b/django_rq/utils.py
@@ -66,7 +66,7 @@ def get_statistics(run_maintenance_tasks=False):
             'oldest_job_timestamp': oldest_job_timestamp,
             'index': index,
             'connection_kwargs': connection_kwargs,
-            'scheduler_PID': scheduler_pid(queue),
+            'scheduler_pid': scheduler_pid(queue),
         }
 
         connection = get_connection(queue.name)

--- a/django_rq/utils.py
+++ b/django_rq/utils.py
@@ -23,8 +23,11 @@ def get_scheduler_pid(queue):
         Note: result might have some delay (1-15 minutes) but it helps visualizing whether the setup is working correcly
     '''
     try:
+        if not queue:
+            raise ValueError("queue argument not defined for rq's Scheduler")
+
         # first try to use rq-scheduler
-        scheduler = get_scheduler()  # should fail if rq_scheduler not present
+        scheduler = get_scheduler(queue.name)  # should fail if rq_scheduler not present
         # currently, scheduler_lock_key is not used but, just in case, try
         lock_key = scheduler.scheduler_lock_key
         with scheduler.connection.pipeline() as p:
@@ -35,8 +38,6 @@ def get_scheduler_pid(queue):
                     if not p.hexists(key, 'death'):
                         return scheduler.pid
     except ImproperlyConfigured:
-        if not queue:
-            raise ValueError("queue argument not defined for rq's Scheduler")
         from rq.scheduler import RQScheduler
         # When a scheduler acquires a lock it adds an expiring key: (e.g: rq:scheduler-lock:<queue.name>)
         # If the key exists

--- a/django_rq/utils.py
+++ b/django_rq/utils.py
@@ -18,7 +18,9 @@ from django.core.exceptions import ImproperlyConfigured
 
 def get_scheduler_pid(queue):
     '''Checks whether there's a scheduler-lock on a particular queue, and returns the PID.
-        If rq_scheduler is used, return True
+        It works by first checking if there's an RQ-Scheduler active.
+        If not, it checks the RQ's RQScheduler for a scheduler lock in the desired queue
+        Note: result might have some delay (1-15 minutes) but it helps visualizing whether the setup is working correcly
     '''
     try:
         # first try to use rq-scheduler

--- a/django_rq/utils.py
+++ b/django_rq/utils.py
@@ -27,11 +27,11 @@ def scheduler_pid(queue):
         lock_key = scheduler.scheduler_lock_key
         with scheduler.connection.pipeline() as p:
             if _ := p.get(lock_key):
-                return scheduler.pid()
+                return scheduler.pid
             else:
                 for key in p.keys(f"{scheduler.redis_scheduler_namespace_prefix}*"):
                     if not p.hexists(key, 'death'):
-                        return scheduler.pid()
+                        return scheduler.pid
     except ImproperlyConfigured:
         from rq.scheduler import RQScheduler
         # When a scheduler acquires a lock it adds an expiring key: (e.g: rq:scheduler-lock:<queue.name>)

--- a/django_rq/utils.py
+++ b/django_rq/utils.py
@@ -27,7 +27,7 @@ def scheduler_pid(queue):
         lock_key = scheduler.scheduler_lock_key
         with scheduler.connection.pipeline() as p:
             if _ := p.get(lock_key):
-                return True  # Since no pid info provided, return True
+                return scheduler.pid()
             else:
                 for key in p.keys(f"{scheduler.redis_scheduler_namespace_prefix}*"):
                     if not p.hexists(key, 'death'):

--- a/django_rq/utils.py
+++ b/django_rq/utils.py
@@ -39,7 +39,7 @@ def scheduler_pid(queue):
         if pid := queue.connection.get(RQScheduler.get_locking_key(queue.name)):
             return pid
     except Exception as e:
-        return str(e)
+        return str(e)  # Temporary
     return None
 
 

--- a/django_rq/utils.py
+++ b/django_rq/utils.py
@@ -21,9 +21,13 @@ def scheduler_pid(queue):
         If rq_scheduler is used, return True
     '''
     try:
+        print("getting scheduler")
         scheduler = get_scheduler()  # should fail if rq_scheduler not present
+        print("got scheduler. getting lock_key")
         lock_key = scheduler.scheduler_lock_key
+        print(f"got lock_key {lock_key}. getting value")
         if _ := scheduler.connection.get(lock_key):
+            print(f"got value {_}, returning True")
             return True  # Since no pid info provided, return True
     except ImproperlyConfigured:
         from rq.scheduler import RQScheduler
@@ -31,6 +35,8 @@ def scheduler_pid(queue):
         # If the key exists
         if pid := queue.connection.get(RQScheduler.get_locking_key(queue.name)):
             return pid
+    except Exception as e:
+        return str(e)
     return None
 
 


### PR DESCRIPTION
Based off @selwin encouragement (#567), This PR adds to the general view the PID of the scheduler.
It handles both rq-scheduler and rq worker --with-scheduler.

it helps visualize whether there's an issue (e.g worker started without scheduler, or rq-scheduler not responding). Since worker-schedulers are queue-specific, it made a lot of sense to add it as a column to the main django-rq view.

It does that by checking scheduler data in redis (getting connection either from the queue or from the scheduler) and considers that rq and rq-scheduler store this differently.

If there's no active scheduler, the column will show "Inactive" (this might take some time since the data in redis has to expire (1~(rq) to 15~ (rq-scheduler) minutes)).

Wrote some tests, but need help in running them (rq has it easier). 
PS: (PIDs can be the same but the schedulers can be different (check the name of the worker to confirm they are different))