### PR TITLE
Feat: Add username support for Sentinel

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,7 @@ Installation
             'HOST': 'localhost',
             'PORT': 6379,
             'DB': 0,
+            'USERNAME': 'some-user',
             'PASSWORD': 'some-password',
             'DEFAULT_TIMEOUT': 360,
         },
@@ -57,10 +58,14 @@ Installation
             'SENTINELS': [('localhost', 26736), ('localhost', 26737)],
             'MASTER_NAME': 'redismaster',
             'DB': 0,
+            # Redis username/password
+            'USERNAME': 'redis-user',
             'PASSWORD': 'secret',
-            'SOCKET_TIMEOUT': None,
-            'CONNECTION_KWARGS': {
-                'socket_connect_timeout': 0.3
+            'SOCKET_TIMEOUT': 0.3,
+            'SENTINEL_KWARGS': {    # Sentinel connection arguments
+                # If Sentinel is also protected, username/password can be passed here
+                'USERNAME': 'sentinel-user',
+                'PASSWORD': 'secret',
             },
         },
         'high': {

--- a/README.rst
+++ b/README.rst
@@ -62,10 +62,13 @@ Installation
             'USERNAME': 'redis-user',
             'PASSWORD': 'secret',
             'SOCKET_TIMEOUT': 0.3,
+            'CONNECTION_KWARGS': {  # Eventual additional Redis connection arguments
+                'ssl': True
+            }
             'SENTINEL_KWARGS': {    # Sentinel connection arguments
                 # If Sentinel is also protected, username/password can be passed here
-                'USERNAME': 'sentinel-user',
-                'PASSWORD': 'secret',
+                'username': 'sentinel-user',
+                'password': 'secret',
             },
         },
         'high': {

--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,9 @@ Installation
             'USERNAME': 'some-user',
             'PASSWORD': 'some-password',
             'DEFAULT_TIMEOUT': 360,
+            'REDIS_CLIENT_KWARGS': {    # Eventual additional Redis connection arguments
+                'ssl_cert_reqs': None,
+            },
         },
         'with-sentinel': {
             'SENTINELS': [('localhost', 26736), ('localhost', 26737)],
@@ -65,8 +68,8 @@ Installation
             'CONNECTION_KWARGS': {  # Eventual additional Redis connection arguments
                 'ssl': True
             }
-            'SENTINEL_KWARGS': {    # Sentinel connection arguments
-                # If Sentinel is also protected, username/password can be passed here
+            'SENTINEL_KWARGS': {    # Eventual Sentinel connection arguments
+                # If Sentinel also has auth, username/password can be passed here
                 'username': 'sentinel-user',
                 'password': 'secret',
             },

--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -118,6 +118,7 @@ def get_redis_connection(config, use_strict_redis=False):
             'username': config.get('USERNAME'),
             'socket_timeout': config.get('SOCKET_TIMEOUT'),
         }
+        connection_kwargs.update(config.get('CONNECTION_KWARGS', {}))
         sentinel_kwargs = config.get('SENTINEL_KWARGS', {})
         sentinel = Sentinel(config['SENTINELS'], sentinel_kwargs=sentinel_kwargs, **connection_kwargs)
         return sentinel.master_for(

--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -112,13 +112,14 @@ def get_redis_connection(config, use_strict_redis=False):
         return redis_cls(unix_socket_path=config['UNIX_SOCKET_PATH'], db=config['DB'])
 
     if 'SENTINELS' in config:
-        sentinel_kwargs = {
+        connection_kwargs = {
             'db': config.get('DB'),
             'password': config.get('PASSWORD'),
+            'username': config.get('USERNAME'),
             'socket_timeout': config.get('SOCKET_TIMEOUT'),
         }
-        sentinel_kwargs.update(config.get('CONNECTION_KWARGS', {}))
-        sentinel = Sentinel(config['SENTINELS'], **sentinel_kwargs)
+        sentinel_kwargs = config.get('SENTINEL_KWARGS', {})
+        sentinel = Sentinel(config['SENTINELS'], sentinel_kwargs=sentinel_kwargs, **connection_kwargs)
         return sentinel.master_for(
             service_name=config['MASTER_NAME'],
             redis_class=redis_cls,

--- a/django_rq/tests/settings.py
+++ b/django_rq/tests/settings.py
@@ -106,9 +106,10 @@ RQ_QUEUES = {
         'SENTINELS': [(REDIS_HOST, 26736), (REDIS_HOST, 26737)],
         'MASTER_NAME': 'testmaster',
         'DB': 1,
+        'USERNAME': 'redis-user',
         'PASSWORD': 'secret',
         'SOCKET_TIMEOUT': 10,
-        'CONNECTION_KWARGS': {},
+        'SENTINEL_KWARGS': {},
     },
     'test1': {
         'HOST': REDIS_HOST,

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -168,12 +168,10 @@ class QueuesTest(TestCase):
         }
         get_redis_connection(config)
         sentinel_init_sentinel_kwargs = sentinel_class_mock.call_args[1]
-        sentinel_init_connection_kwargs = sentinel_class_mock.call_args[2]
+        print(sentinel_init_sentinel_kwargs)
         self.assertDictEqual(
-            sentinel_init_sentinel_kwargs, {'username': 'sentinel-user', 'password': 'sentinel-pass', 'socket_timeout': 0.3}
-        )
-        self.assertDictEqual(
-            sentinel_init_connection_kwargs, {'db': 0, 'username': 'redis-user', 'password': 'redis-pass', 'socket_timeout': 0.2}
+            sentinel_init_sentinel_kwargs, 
+            {'db': 0, 'username': 'redis-user', 'password': 'redis-pass', 'socket_timeout': 0.2, 'sentinel_kwargs': {'username': 'sentinel-user', 'password': 'sentinel-pass', 'socket_timeout': 0.3}}
         )
 
     def test_get_queue_default(self):

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -169,7 +169,6 @@ class QueuesTest(TestCase):
         }
         get_redis_connection(config)
         sentinel_init_sentinel_kwargs = sentinel_class_mock.call_args[1]
-        print(sentinel_init_sentinel_kwargs)
         self.assertDictEqual(
             sentinel_init_sentinel_kwargs, 
             {'db': 0, 'username': 'redis-user', 'password': 'redis-pass', 'socket_timeout': 0.2, 'ssl': False, 'sentinel_kwargs': {'username': 'sentinel-user', 'password': 'sentinel-pass', 'socket_timeout': 0.3}}

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -164,6 +164,7 @@ class QueuesTest(TestCase):
             'DB': 0,
             'USERNAME': 'redis-user',
             'PASSWORD': 'redis-pass',
+            'CONNECTION_KWARGS': {'ssl': False},
             'SENTINEL_KWARGS': {'username': 'sentinel-user', 'password': 'sentinel-pass', 'socket_timeout': 0.3},
         }
         get_redis_connection(config)
@@ -171,7 +172,7 @@ class QueuesTest(TestCase):
         print(sentinel_init_sentinel_kwargs)
         self.assertDictEqual(
             sentinel_init_sentinel_kwargs, 
-            {'db': 0, 'username': 'redis-user', 'password': 'redis-pass', 'socket_timeout': 0.2, 'sentinel_kwargs': {'username': 'sentinel-user', 'password': 'sentinel-pass', 'socket_timeout': 0.3}}
+            {'db': 0, 'username': 'redis-user', 'password': 'redis-pass', 'socket_timeout': 0.2, 'ssl': False, 'sentinel_kwargs': {'username': 'sentinel-user', 'password': 'sentinel-pass', 'socket_timeout': 0.3}}
         )
 
     def test_get_queue_default(self):

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -162,12 +162,18 @@ class QueuesTest(TestCase):
             'MASTER_NAME': 'test_master',
             'SOCKET_TIMEOUT': 0.2,
             'DB': 0,
-            'CONNECTION_KWARGS': {'socket_connect_timeout': 0.3},
+            'USERNAME': 'redis-user',
+            'PASSWORD': 'redis-pass',
+            'SENTINEL_KWARGS': {'username': 'sentinel-user', 'password': 'sentinel-pass', 'socket_timeout': 0.3},
         }
         get_redis_connection(config)
-        sentinel_init_kwargs = sentinel_class_mock.call_args[1]
+        sentinel_init_sentinel_kwargs = sentinel_class_mock.call_args[1]
+        sentinel_init_connection_kwargs = sentinel_class_mock.call_args[2]
         self.assertDictEqual(
-            sentinel_init_kwargs, {'socket_connect_timeout': 0.3, 'db': 0, 'socket_timeout': 0.2, 'password': None}
+            sentinel_init_sentinel_kwargs, {'username': 'sentinel-user', 'password': 'sentinel-pass', 'socket_timeout': 0.3}
+        )
+        self.assertDictEqual(
+            sentinel_init_connection_kwargs, {'db': 0, 'username': 'redis-user', 'password': 'redis-pass', 'socket_timeout': 0.2}
         )
 
     def test_get_queue_default(self):


### PR DESCRIPTION
resolves #575

- Passing username to Sentinel args
- Updated connection_kwargs and sentinel_kwargs according to [redis-py doc](https://redis.readthedocs.io/en/stable/connections.html#sentinel-client)
- Udpated the documentation
- Updated the tests