### PR TITLE
Add support for rqworker's custom Serializer

### DIFF
--- a/django_rq/management/commands/rqworker.py
+++ b/django_rq/management/commands/rqworker.py
@@ -81,6 +81,8 @@ class Command(BaseCommand):
                             help='Turns debug mode on or off.')
         parser.add_argument('--max-jobs', action='store', default=None, dest='max_jobs', type=int,
                             help='Maximum number of jobs to execute')
+        parser.add_argument('--serializer', action='store', default='rq.serializers.DefaultSerializer', dest='serializer',
+                            help='Specify a custom Serializer.')
         parser.add_argument('args', nargs='*', type=str,
                             help='The queues to work on, separated by space')
 
@@ -116,6 +118,7 @@ class Command(BaseCommand):
                 'job_class': options['job_class'],
                 'name': options['name'],
                 'default_worker_ttl': options['worker_ttl'],
+                'serializer': options['serializer']
             }
             w = get_worker(*args, **worker_kwargs)
 

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -17,6 +17,7 @@ from rq.exceptions import NoSuchJobError
 from rq.job import Job
 from rq.registry import FinishedJobRegistry, ScheduledJobRegistry
 from rq.worker import Worker
+from rq.serializers import DefaultSerializer, JSONSerializer
 
 from django_rq.decorators import job
 from django_rq.jobs import get_job_class
@@ -544,6 +545,16 @@ class WorkersTest(TestCase):
         self.assertIs(w.job_class, DummyJob)
         self.assertIsInstance(w.queues[0], DummyQueue)
         self.assertIsInstance(w, DummyWorker)
+
+    def test_get_worker_custom_serializer(self):
+        w = get_worker(
+            serializer='rq.serializers.JSONSerializer',
+        )
+        self.assertEqual(w.serializer, JSONSerializer)
+
+    def test_get_worker_default_serializer(self):
+        w = get_worker()
+        self.assertEqual(w.serializer, DefaultSerializer)
 
     def test_get_current_job(self):
         """


### PR DESCRIPTION
@selwin adding support for custom serializers (trying to keep up with rq worker arguments that are not available for the rqworker command). Tests included.