### PR TITLE
More permissive urls for customized job_ids

### DIFF
--- a/django_rq/urls.py
+++ b/django_rq/urls.py
@@ -2,7 +2,6 @@ from django.urls import re_path
 
 from . import views
 
-
 urlpatterns = [
     re_path(r'^$', views.stats, name='rq_home'),
     re_path(r'^stats.json/(?P<token>[\w]+)?/?$', views.stats_json, name='rq_home_json'),
@@ -16,18 +15,18 @@ urlpatterns = [
     re_path(r'^queues/(?P<queue_index>[\d]+)/deferred/$', views.deferred_jobs, name='rq_deferred_jobs'),
     re_path(r'^queues/(?P<queue_index>[\d]+)/empty/$', views.clear_queue, name='rq_clear'),
     re_path(r'^queues/(?P<queue_index>[\d]+)/requeue-all/$', views.requeue_all, name='rq_requeue_all'),
-    re_path(r'^queues/(?P<queue_index>[\d]+)/(?P<job_id>[-\w\.\:\$]+)/$', views.job_detail, name='rq_job_detail'),
+    re_path(r'^queues/(?P<queue_index>[\d]+)/(?P<job_id>[^/]+)/$', views.job_detail, name='rq_job_detail'),
     re_path(
-        r'^queues/(?P<queue_index>[\d]+)/(?P<job_id>[-\w\.\:\$]+)/delete/$', views.delete_job, name='rq_delete_job'
+        r'^queues/(?P<queue_index>[\d]+)/(?P<job_id>[^/]+)/delete/$', views.delete_job, name='rq_delete_job'
     ),
     re_path(r'^queues/confirm-action/(?P<queue_index>[\d]+)/$', views.confirm_action, name='rq_confirm_action'),
     re_path(r'^queues/actions/(?P<queue_index>[\d]+)/$', views.actions, name='rq_actions'),
     re_path(
-        r'^queues/(?P<queue_index>[\d]+)/(?P<job_id>[-\w\.\:\$]+)/requeue/$',
+        r'^queues/(?P<queue_index>[\d]+)/(?P<job_id>[^/]+)/requeue/$',
         views.requeue_job_view,
         name='rq_requeue_job',
     ),
     re_path(
-        r'^queues/(?P<queue_index>[\d]+)/(?P<job_id>[-\w\.\:\$]+)/enqueue/$', views.enqueue_job, name='rq_enqueue_job'
+        r'^queues/(?P<queue_index>[\d]+)/(?P<job_id>[^/]+)/enqueue/$', views.enqueue_job, name='rq_enqueue_job'
     ),
 ]


### PR DESCRIPTION
Virtually any string is a valid rq job_id. I think the only real requirement is that it be a valid redis key, and Redis supports arbitrary binary keys. This PR expands the url patterns so that fewer customized job_ids cause a 500 while viewing the queue.