### PR TITLE
Fix Exception Rendering on Job Details Template

### DIFF
--- a/django_rq/templates/django_rq/job_detail.html
+++ b/django_rq/templates/django_rq/job_detail.html
@@ -167,7 +167,7 @@
             <div class="form-row">
                 <div>
                     <label>Exception:</label>
-                    <div><pre>{% if job.exc_info %}{{ job.exc_info|linebreaks }}{% endif %}</pre></div>
+                    <div><pre>{{ job.exc_info|linebreaks }}</pre></div>
                 </div>
             </div>
         {% endif %}

--- a/django_rq/templates/django_rq/job_detail.html
+++ b/django_rq/templates/django_rq/job_detail.html
@@ -163,7 +163,7 @@
                 </div>
             </div>
         </div>
-        {% if exc_info %}
+        {% if job.exc_info %}
             <div class="form-row">
                 <div>
                     <label>Exception:</label>


### PR DESCRIPTION
## Issue
The stack trace that caused a job to fail was not displayed for failed jobs on the job details admin screen. 
The html block was wrapped in an if statement checking a non-existent variable exc_info instead of job.exc_info

## Fix
Update the if check to check job.exc_info instead of exc_info