### PR TITLE
Fix layout of the deletelink button

### DIFF
--- a/django_rq/templates/django_rq/job_detail.html
+++ b/django_rq/templates/django_rq/job_detail.html
@@ -185,7 +185,7 @@
         
 
     <div class="submit-row">
-        <p class="deletelink-box"><a href="delete/" class="deletelink">Delete</a></p>
+        <div class="deletelink-box"><a href="delete/" class="deletelink">Delete</a></div>
         {% if job.is_started %}
             <form method = 'POST' action = "{% url 'rq_stop_job' queue_index job.id %}">
                 {% csrf_token %}


### PR DESCRIPTION
This PR fixes a minor layout shift issue in the job detail page of the admin panel. 

Before : 
![image](https://github.com/rq/django-rq/assets/16188760/a1c3ef60-c0a0-4b15-9aa3-e0c0809a8c52)

After : 
<img width="200" alt="image" src="https://github.com/rq/django-rq/assets/16188760/225d6aa4-6269-4279-9fe6-87cf37a145b5">
