### PR TITLE
Specify queue serializer when creating Django RQ queue

### DIFF
--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -155,6 +155,7 @@ def get_queue(
     connection=None,
     queue_class=None,
     job_class=None,
+    serializer=None,
     **kwargs
 ):
     """
@@ -176,6 +177,8 @@ def get_queue(
         default_timeout = QUEUES[name].get('DEFAULT_TIMEOUT')
     if connection is None:
         connection = get_connection(name)
+    if serializer is None:
+        serializer = QUEUES[name].get('SERIALIZER')
     queue_class = get_queue_class(QUEUES[name], queue_class)
     return queue_class(
         name,
@@ -184,6 +187,7 @@ def get_queue(
         is_async=is_async,
         job_class=job_class,
         autocommit=autocommit,
+        serializer=serializer,
         **kwargs
     )
 
@@ -196,7 +200,10 @@ def get_queue_by_index(index):
 
     config = QUEUES_LIST[int(index)]
     return get_queue_class(config)(
-        config['name'], connection=get_redis_connection(config['connection_config']), is_async=config.get('ASYNC', True)
+        config['name'],
+        connection=get_redis_connection(config['connection_config']),
+        is_async=config.get('ASYNC', True),
+        serializer=config['connection_config'].get('SERIALIZER')
     )
 
 def get_scheduler_by_index(index):

--- a/django_rq/tests/settings.py
+++ b/django_rq/tests/settings.py
@@ -187,6 +187,12 @@ RQ_QUEUES = {
         'DB': 0,
         'DEFAULT_TIMEOUT': 400,
     },
+    'test_serializer': {
+        'HOST': REDIS_HOST,
+        'PORT': 6379,
+        'DB': 0,
+        'SERIALIZER': 'rq.serializers.JSONSerializer',
+    },
 }
 RQ = {
     'AUTOCOMMIT': False,

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -13,6 +13,7 @@ from django.utils.safestring import SafeString
 
 from redis.exceptions import ConnectionError
 from rq import get_current_job, Queue
+import rq
 from rq.exceptions import NoSuchJobError
 from rq.job import Job
 from rq.registry import FinishedJobRegistry, ScheduledJobRegistry
@@ -456,6 +457,14 @@ class QueuesTest(TestCase):
         self.assertEqual(queue._default_timeout, 500)
         queue = get_queue('test1')
         self.assertEqual(queue._default_timeout, 400)
+
+    def test_get_queue_serializer(self):
+        """
+        Test that the correct serializer is set on the queue.
+        """
+        queue = get_queue('test_serializer')
+        self.assertEqual(queue.name, 'test_serializer')
+        self.assertEqual(queue.serializer, rq.serializers.JSONSerializer)
 
 
 @override_settings(RQ={'AUTOCOMMIT': True})

--- a/django_rq/utils.py
+++ b/django_rq/utils.py
@@ -120,7 +120,7 @@ def get_jobs(queue, job_ids, registry=None):
     1. If job data is not present in Redis, discard the result
     2. If `registry` argument is supplied, delete empty jobs from registry
     """
-    jobs = Job.fetch_many(job_ids, connection=queue.connection)
+    jobs = Job.fetch_many(job_ids, connection=queue.connection, serializer=queue.serializer)
     valid_jobs = []
     for i, job in enumerate(jobs):
         if job is None:


### PR DESCRIPTION
Related to this issue: https://github.com/rq/django-rq/issues/626 

We want to be able to add the serializer when creating the Django RQ queue. This serializer should then automatically be used when fetching the jobs so that we do not get `DeserializationError` in the Django RQ dashboard.