### PR TITLE
Account for missing db in connection kwargs

### DIFF
--- a/django_rq/utils.py
+++ b/django_rq/utils.py
@@ -102,7 +102,7 @@ def get_scheduler_statistics():
         # jobs in more than one of them
         queue = get_queue_by_index(index)
         connection_kwargs = queue.connection.connection_pool.connection_kwargs
-        conn_key = f"{connection_kwargs['host']}:{connection_kwargs['port']}/{connection_kwargs['db']}"
+        conn_key = f"{connection_kwargs['host']}:{connection_kwargs['port']}/{connection_kwargs.get('db', 0)}"
         if conn_key not in schedulers:
             try:
                 scheduler = get_scheduler(config['name'])


### PR DESCRIPTION
When the `db` value is not included explicitly in the connection kwargs the default `0` db is used but this is not reflected in the connection kwargs.

Closes gh-632