### PR TITLE
Use datetime.timezone.utc as Django 5.0 removed the alias.

### DIFF
--- a/django_rq/templatetags/django_rq.py
+++ b/django_rq/templatetags/django_rq.py
@@ -1,3 +1,5 @@
+import datetime
+
 from django import template
 from django.utils import timezone
 from django.utils.html import escape
@@ -10,7 +12,7 @@ register = template.Library()
 def to_localtime(time):
     """Converts naive datetime to localtime based on settings"""
 
-    utc_time = time.replace(tzinfo=timezone.utc)
+    utc_time = time.replace(tzinfo=datetime.timezone.utc)
     to_zone = timezone.get_default_timezone()
     return utc_time.astimezone(to_zone)
 


### PR DESCRIPTION
From the release notes: https://docs.djangoproject.com/en/5.0/releases/5.0/#features-removed-in-5-0

> The django.utils.timezone.utc alias to datetime.timezone.utc is removed.

Resolves #610 