### PR TITLE
Fixed models.W042 warning.

### DIFF
--- a/django_rq/apps.py
+++ b/django_rq/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class DjangoRqAdminConfig(AppConfig):
+    default_auto_field = "django.db.models.AutoField"
+    name = "django_rq"


### PR DESCRIPTION
```
django_rq.Queue: (models.W042) Auto-created primary key used when not defining a primary key type, by default 'django.db.models.AutoField'.
	HINT: Configure the DEFAULT_AUTO_FIELD setting or the AppConfig.default_auto_field attribute to point to a subclass of AutoField, e.g. 'django.db.models.BigAutoField'.
````