### PR TITLE
Worker pool handles spawned process

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Python${{ matrix.python-version }}/Django${{ matrix.django-version }}
+
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: django_rq_test_db
+        ports:
+          - 5432:5432
+
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,4 +49,4 @@ jobs:
 
     - name: Run Test
       run: |
-        `which django-admin` test django_rq --settings=django_rq.tests.settings --pythonpath=.
+        `which django-admin` test django_rq --settings=django_rq.tests.settings --pythonpath=. --noinput

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,7 +45,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install django==${{ matrix.django-version }}
-        pip install redis django-redis rq sentry-sdk rq-scheduler
+        pip install redis django-redis rq sentry-sdk rq-scheduler psycopg2-binary
 
     - name: Run Test
       run: |

--- a/django_rq/management/commands/rqworker-pool.py
+++ b/django_rq/management/commands/rqworker-pool.py
@@ -1,3 +1,4 @@
+import multiprocessing as mp
 import os
 import sys
 
@@ -7,7 +8,7 @@ from rq.serializers import resolve_serializer
 from django.core.management.base import BaseCommand
 
 from ...jobs import get_job_class
-from ...utils import configure_sentry
+from ...utils import configure_sentry, reset_db_connections
 from ...queues import get_queues
 from ...workers import get_worker_class
 from ...worker_pool import DjangoWorkerPool
@@ -97,4 +98,7 @@ class Command(BaseCommand):
             worker_class=worker_class,
             job_class=job_class,
         )
+        # Close any opened DB connection before any fork
+        reset_db_connections()
+        mp.set_start_method('fork', force=True)
         pool.start(burst=options.get('burst', False), logging_level=logging_level)

--- a/django_rq/management/commands/rqworker-pool.py
+++ b/django_rq/management/commands/rqworker-pool.py
@@ -1,9 +1,8 @@
 import os
 import sys
 
-from rq.serializers import resolve_serializer
-from rq.worker_pool import WorkerPool
 from rq.logutils import setup_loghandlers
+from rq.serializers import resolve_serializer
 
 from django.core.management.base import BaseCommand
 
@@ -11,6 +10,7 @@ from ...jobs import get_job_class
 from ...utils import configure_sentry
 from ...queues import get_queues
 from ...workers import get_worker_class
+from ...worker_pool import DjangoWorkerPool
 
 
 class Command(BaseCommand):
@@ -89,7 +89,7 @@ class Command(BaseCommand):
         worker_class = get_worker_class(options.get('worker_class', None))
         serializer = resolve_serializer(options['serializer'])
 
-        pool = WorkerPool(
+        pool = DjangoWorkerPool(
             queues=queues,
             connection=queues[0].connection,
             num_workers=options['num_workers'],

--- a/django_rq/tests/settings.py
+++ b/django_rq/tests/settings.py
@@ -40,7 +40,7 @@ INSTALLED_APPS = [
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'django_rq_test_db',
+        'NAME': 'django_rq_db',
         'USER': 'postgres',
         'PASSWORD': 'postgres',
         'HOST': 'localhost',

--- a/django_rq/tests/settings.py
+++ b/django_rq/tests/settings.py
@@ -40,8 +40,11 @@ INSTALLED_APPS = [
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': ':memory:',
-    },
+        'NAME': 'test_db.sqlite3',
+        'TEST': {
+            'NAME': 'test_db.sqlite3',
+        }
+    }
 }
 
 if REDIS_CACHE_TYPE == 'django-redis':

--- a/django_rq/tests/settings.py
+++ b/django_rq/tests/settings.py
@@ -39,12 +39,16 @@ INSTALLED_APPS = [
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': 'test_db.sqlite3',
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'django_rq_test_db',
+        'USER': 'postgres',
+        'PASSWORD': 'postgres',
+        'HOST': 'localhost',
+        'PORT': '5432',
         'TEST': {
-            'NAME': 'test_db.sqlite3',
+            'NAME': 'django_rq_test_db',
         }
-    }
+    },
 }
 
 if REDIS_CACHE_TYPE == 'django-redis':

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -308,7 +308,7 @@ class QueuesTest(TestCase):
 
     def test_rqworker_pool_process_start_method(self) -> None:
         for start_method in ['spawn', 'fork']:
-            with mock.patch.object(multiprocessing, "get_start_method", return_value=start_method):
+            with mock.patch.object(multiprocessing, 'get_start_method', return_value=start_method):
                 queue_name = 'django_rq_test'
                 queue = get_queue(queue_name)
                 job = queue.enqueue(query_user)

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -38,7 +38,7 @@ from django_rq.tests.fixtures import DummyJob, DummyQueue, DummyWorker
 from django_rq.utils import get_jobs, get_statistics, get_scheduler_pid
 from django_rq.workers import get_worker, get_worker_class
 
-from .utils import query_queue
+from .utils import query_user
 
 try:
     from rq_scheduler import Scheduler
@@ -311,7 +311,7 @@ class QueuesTest(TestCase):
             with mock.patch.object(multiprocessing, "get_start_method", return_value=start_method):
                 queue_name = 'django_rq_test'
                 queue = get_queue(queue_name)
-                job = queue.enqueue(query_queue)
+                job = queue.enqueue(query_user)
                 finished_job_registry = FinishedJobRegistry(queue.name, queue.connection)
                 call_command('rqworker-pool', queue_name, burst=True)
 

--- a/django_rq/tests/utils.py
+++ b/django_rq/tests/utils.py
@@ -1,4 +1,5 @@
 from django_rq.queues import get_connection, get_queue_by_index
+from django_rq.models import Queue
 
 
 def get_queue_index(name='default'):
@@ -17,3 +18,7 @@ def get_queue_index(name='default'):
             queue_index = i
             break
     return queue_index
+
+
+def query_queue():
+    return Queue.objects.first()

--- a/django_rq/tests/utils.py
+++ b/django_rq/tests/utils.py
@@ -1,8 +1,11 @@
+from typing import Optional
+
 from django_rq.queues import get_connection, get_queue_by_index
-from django_rq.models import Queue
+
+from django.contrib.auth.models import User
 
 
-def get_queue_index(name='default'):
+def get_queue_index(name: str = 'default') -> int:
     """
     Returns the position of Queue for the named queue in QUEUES_LIST
     """
@@ -20,5 +23,5 @@ def get_queue_index(name='default'):
     return queue_index
 
 
-def query_queue():
-    return Queue.objects.first()
+def query_user() -> Optional[User]:
+    return User.objects.first()

--- a/django_rq/tests/utils.py
+++ b/django_rq/tests/utils.py
@@ -24,4 +24,8 @@ def get_queue_index(name: str = 'default') -> int:
 
 
 def query_user() -> Optional[User]:
-    return User.objects.first()
+    try:
+        return User.objects.first()
+    except Exception as e:
+        print('Exception caught when querying user: ', e)
+        raise e

--- a/django_rq/worker_pool.py
+++ b/django_rq/worker_pool.py
@@ -1,0 +1,38 @@
+import django
+from multiprocessing import Process, get_start_method
+from typing import Any
+
+from rq.worker_pool import WorkerPool, run_worker
+
+
+class DjangoWorkerPool(WorkerPool):
+    def get_worker_process(
+        self,
+        name: str,
+        burst: bool,
+        _sleep: float = 0,
+        logging_level: str = "INFO",
+    ) -> Process:
+        """Returns the worker process"""
+        return Process(
+            target=run_django_worker,
+            args=(name, self._queue_names, self._connection_class, self._pool_class, self._pool_kwargs),
+            kwargs={
+                '_sleep': _sleep,
+                'burst': burst,
+                'logging_level': logging_level,
+                'worker_class': self.worker_class,
+                'job_class': self.job_class,
+                'serializer': self.serializer,
+            },
+            name=f'Worker {name} (WorkerPool {self.name})',
+        )
+
+
+def run_django_worker(*args: Any, **kwargs: Any) -> None:
+    # multiprocessing library default process start method may be
+    # `spawn` or `fork` depending on the host OS
+    if get_start_method() == 'spawn':
+        django.setup()
+
+    run_worker(*args, **kwargs)


### PR DESCRIPTION
Fix #651
Ref #650

I can't reproduce the issue in #650, but I did get the same errors in #651
Seems like its an issue with `multiprocessing` start method in certain OS, as was answered in this stack overflow post: https://stackoverflow.com/questions/46908035/apps-arent-loaded-yet-exception-occurs-when-using-multi-processing-in-django

This solution builds on top of @jackkinsella answer, and can be updated further to handle his specific issue. 