### PR TITLE
Make `rqstats -y` fail when PyYAML is not installed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install django==${{ matrix.django-version }}
-        pip install redis django-redis rq sentry-sdk rq-scheduler
+        pip install django==${{ matrix.django-version }} \
+          redis django-redis pyyaml rq sentry-sdk rq-scheduler
 
     - name: Run Test
       run: |

--- a/django_rq/management/commands/rqstats.py
+++ b/django_rq/management/commands/rqstats.py
@@ -1,7 +1,7 @@
 import click
 import time
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 from ...utils import get_statistics
 
@@ -85,9 +85,9 @@ class Command(BaseCommand):
         if options.get("yaml"):
             try:
                 import yaml
-            except ImportError:
-                click.echo("Aborting. LibYAML is not installed.")
-                return
+            except ImportError as ex:
+                raise CommandError("PyYAML is not installed.") from ex
+
             # Disable YAML alias
             yaml.Dumper.ignore_aliases = lambda *args: True
             click.echo(yaml.dump(get_statistics(), default_flow_style=False))


### PR DESCRIPTION
Currently, when PyYAML is not installed, `rqstats -y` prints an error message, but it still exits with a 0 exit code, indicating success. Fix that, along with a few related issues:

* The error message was printed to stdout rather than stderr.

* The name of the library in the message was incorrect (LibYAML is a C library; the Python library is PyYAML).

After this change, you need to install PyYAML to run the testsuite, so modify the GitHub workflow accordingly. Also, make sure to install all packages at once, to make sure that later install commands don't overwrite the result of the earlier ones.