### PR TITLE
Expose --max-idle-time RQ flag in rqworker management command

### DIFF
--- a/django_rq/management/commands/rqworker.py
+++ b/django_rq/management/commands/rqworker.py
@@ -47,6 +47,8 @@ class Command(BaseCommand):
                             help='Turns debug mode on or off.')
         parser.add_argument('--max-jobs', action='store', default=None, dest='max_jobs', type=int,
                             help='Maximum number of jobs to execute')
+        parser.add_argument('--max-idle-time', action='store', default=None, dest='max_idle_time', type=int,
+                            help='Seconds to wait for job before shutting down')
         parser.add_argument('--serializer', action='store', default='rq.serializers.DefaultSerializer', dest='serializer',
                             help='Specify a custom Serializer.')
         parser.add_argument('args', nargs='*', type=str,
@@ -93,7 +95,7 @@ class Command(BaseCommand):
 
             w.work(
                 burst=options.get('burst', False), with_scheduler=options.get('with_scheduler', False),
-                logging_level=level, max_jobs=options['max_jobs']
+                logging_level=level, max_jobs=options['max_jobs'], max_idle_time=options['max_idle_time']
             )
         except ConnectionError as e:
             self.stderr.write(str(e))


### PR DESCRIPTION
Django-rq currently does not expose the --max-idle-time flag that python-rq is able to use under the hood to gracefully shut down a worker after a given amount of seconds. Exposing this functionality proves useful in the event when django-rq workers are run within an autoscaling situation where scale-down time cannot be controlled (e.g.: Azure Container Apps).

By running the worker with `./manage.py rqworker --max-idle-time 60 default` the worker can gracefully shutdown before it gets killed by autoscaling, avoiding interrupted jobs that fail with an error of:

`Work-horse terminated unexpectedly; waitpid returned 15 (signal 15);`

Since `--max-jobs` is already exposed in the rqworker management command, exposing this option is trivial.

Testing process:
- When the flag is not used, the worker functions as expected.
- When the flag is used, the worker exited after 60 seconds:

```
webapp@e15bb6d1e70d$ ./manage.py rqworker --max-idle-time 60 default
13:03:05 Worker rq:worker:05c2a12455804f9d8a3555f5d004837d started with PID 59, version 2.0.0
13:03:05 Subscribing to channel rq:pubsub:05c2a12455804f9d8a3555f5d004837d
13:03:05 *** Listening on default...
13:03:05 Cleaning registries for queue: default
13:04:05 Worker rq:worker:05c2a12455804f9d8a3555f5d004837d: idle for 60 seconds, quitting
13:04:05 Unsubscribing from channel rq:pubsub:05c2a12455804f9d8a3555f5d004837d
```