### PR TITLE
Allow setting DEFAULT_RESULT_TTL in RQ_QUEUES

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,7 @@ Installation
             'USERNAME': 'some-user',
             'PASSWORD': 'some-password',
             'DEFAULT_TIMEOUT': 360,
+            'DEFAULT_RESULT_TTL': 800,
             'REDIS_CLIENT_KWARGS': {    # Eventual additional Redis connection arguments
                 'ssl_cert_reqs': None,
             },

--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -63,6 +63,11 @@ class DjangoRQ(Queue):
         super(DjangoRQ, self).__init__(*args, **kwargs)
 
     def original_enqueue_call(self, *args, **kwargs):
+        from .settings import QUEUES
+
+        queue_name = kwargs.get('queue_name') or self.name
+        kwargs['result_ttl'] = QUEUES[queue_name].get('DEFAULT_RESULT_TTL')
+
         return super(DjangoRQ, self).enqueue_call(*args, **kwargs)
 
     def enqueue_call(self, *args, **kwargs):

--- a/django_rq/tests/settings.py
+++ b/django_rq/tests/settings.py
@@ -89,7 +89,13 @@ LOGGING = {
 
 
 RQ_QUEUES = {
-    'default': {'HOST': REDIS_HOST, 'PORT': 6379, 'DB': 0, 'DEFAULT_TIMEOUT': 500},
+    'default': {
+        'HOST': REDIS_HOST,
+        'PORT': 6379,
+        'DB': 0,
+        'DEFAULT_TIMEOUT': 500,
+        'DEFAULT_RESULT_TTL': 500,
+    },
     'test': {
         'HOST': REDIS_HOST,
         'PORT': 1,
@@ -120,6 +126,7 @@ RQ_QUEUES = {
         'HOST': REDIS_HOST,
         'PORT': 6379,
         'DB': 1,
+        'DEFAULT_RESULT_TTL': 800,
     },
     'async': {
         'HOST': REDIS_HOST,

--- a/django_rq/tests/test_views.py
+++ b/django_rq/tests/test_views.py
@@ -265,8 +265,8 @@ class ViewTest(TestCase):
         response = self.client.get(reverse('rq_scheduled_jobs', args=[queue_index]))
         self.assertEqual(response.context['jobs'], [job])
 
-        # Test that page doesn't crash when job_id has special characters
-        queue.enqueue_at(datetime.now(), access_self, job_id="job-!@#$%^&*()_=+[]{};':,.<>?|`~")
+        # Test that page doesn't crash when job_id has special characters (exclude :)
+        queue.enqueue_at(datetime.now(), access_self, job_id="job-!@#$%^&*()_=+[]{};',.<>?|`~")
         response = self.client.get(reverse('rq_scheduled_jobs', args=[queue_index]))
         self.assertEqual(response.status_code, 200)
 

--- a/django_rq/tests/tests.py
+++ b/django_rq/tests/tests.py
@@ -480,6 +480,18 @@ class QueuesTest(TestCase):
         self.assertEqual(queue.name, 'test_serializer')
         self.assertEqual(queue.serializer, rq.serializers.JSONSerializer)
 
+    def test_enqueue_default_result_ttl(self):
+        """Ensure DEFAULT_RESULT_TTL are properly parsed."""
+        queue = get_queue()
+        job = queue.enqueue(divide, 1, 1)
+        self.assertEqual(job.result_ttl, 500)
+        job.delete()
+
+        queue = get_queue('test3')
+        job = queue.enqueue(divide, 1, 1)
+        self.assertEqual(job.result_ttl, 800)
+        job.delete()
+
 
 @override_settings(RQ={'AUTOCOMMIT': True})
 class DecoratorTest(TestCase):
@@ -518,14 +530,14 @@ class DecoratorTest(TestCase):
         self.assertEqual(result.result_ttl, DEFAULT_RESULT_TTL)
         result.delete()
 
-    @override_settings(RQ={'AUTOCOMMIT': True, 'DEFAULT_RESULT_TTL': 5432})
+    @override_settings(RQ={'AUTOCOMMIT': True})
     def test_job_decorator_result_ttl(self):
         @job
         def test():
             pass
 
         result = test.delay()
-        self.assertEqual(result.result_ttl, 5432)
+        self.assertEqual(result.result_ttl, 500, msg='value added in RQ_QUEUES default')
         result.delete()
 
     @override_settings(RQ={'AUTOCOMMIT': True, 'DEFAULT_RESULT_TTL': 0})
@@ -535,7 +547,7 @@ class DecoratorTest(TestCase):
             pass
 
         result = test.delay()
-        self.assertEqual(result.result_ttl, 0)
+        self.assertEqual(result.result_ttl, 500, msg='value added in RQ_QUEUES default')
         result.delete()
 
 


### PR DESCRIPTION
DEFAULT_RESULT_TTL is only set in the settings RQ, this value though does not apply to queue outside the `default` queue, other queues have their default value as 500 (this is default set in RQ)

This PR allows adding DEFAULT_RESULT_TTL to the RQ_QUEUES, hence controlling the time it takes for job result to leave the queue.

This is a response to the issue - #329 .