### PR TITLE
[FIX] -- job status display in scheduler listing page template.

### DIFF
--- a/django_rq/templates/django_rq/scheduler.html
+++ b/django_rq/templates/django_rq/scheduler.html
@@ -93,7 +93,7 @@
                                         {{ job.ended_at|to_localtime|date:"Y-m-d, H:i:s" }}
                                     {% endif %}
                                 </td>
-                                <td>{{ job.get_status }}</td>
+                                <td>{{ job.get_status.value }}</td>
                                 <td>{{ job|show_func_name }}</td>
                             </tr>
                         {% endfor %}


### PR DESCRIPTION
### **Fix job status display in scheduler template**  

#### **Description**  
This PR updates `scheduler.html` to correctly display the job status by using `job.get_status.value` instead of `job.get_status`.  

#### **Changes**  
- Updated job status display in `scheduler.html`.  
- Affects the scheduler view at `/django-rq/schedulers/<scheduler_id>/`.  

#### **Before Screenshot:**  
![Before PR](https://github.com/user-attachments/assets/910a76bb-e765-44d5-bd78-9e65db1b52d7)  

#### **After Screenshot:**  
![After PR](https://github.com/user-attachments/assets/4d9e2d4a-0a7b-447e-b990-96bfbfd5aedc)  

#### **Testing**  
- Verified that the job status is displayed correctly in the scheduler view.  
- Ensured no other UI elements were affected.  