### PR TITLE
fix typo in setup.py package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     include_package_data=True,
     package_data={
         '': ['README.rst'],
-        'rq': ['py.typed'],
+        'django_rq': ['py.typed'],
     },
     install_requires=['django>=3.2', 'rq>=2', 'redis>=3.5'],
     extras_require={


### PR DESCRIPTION
This change fixes a typo in setup.py package_data which prevents the type information from being exported.

fixes: https://github.com/rq/django-rq/issues/699