### PR TITLE
fix Django admin object-tools breaking job detail view

### DIFF
--- a/django_rq/templates/django_rq/job_detail.html
+++ b/django_rq/templates/django_rq/job_detail.html
@@ -29,6 +29,9 @@
 
 {% block content_title %}<h2>Job {{ job.id }}</h2>{% endblock %}
 
+{# do not render object-tools (fix until https://github.com/django/django/pull/19389/files is released) #}
+{% block object-tools %}{% endblock %}
+
 {% block content %}
 
 <div id="content-main">


### PR DESCRIPTION
This change removes the object-tools from the job detail-view.

fixes: https://github.com/rq/django-rq/issues/698
x-ref: https://code.djangoproject.com/ticket/36331
x-ref: https://github.com/django/django/pull/19389