### PR TITLE
fix job decorator default ttl

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -200,7 +200,7 @@ via ``DEFAULT_RESULT_TTL`` setting:
     }
 
 With this setting, job decorator will set ``result_ttl`` to 5000 unless it's
-specified explicitly.
+specified explicitly or included in the queue config.
 
 
 Running workers

--- a/django_rq/decorators.py
+++ b/django_rq/decorators.py
@@ -1,10 +1,8 @@
 from rq.decorators import job as _rq_job
 from typing import Any, Callable, Optional, overload, Protocol, TYPE_CHECKING, TypeVar, Union
 
-from django.conf import settings
+from .queues import get_queue, get_result_ttl
 
-from .queues import get_queue
-from .settings import QUEUES
 
 if TYPE_CHECKING:
     from redis import Redis
@@ -67,7 +65,7 @@ def job(
         if connection is None:
             connection = queue.connection
 
-    kwargs['result_ttl'] = kwargs.get('result_ttl', QUEUES[queue_name].get('DEFAULT_RESULT_TTL'))
+    kwargs['result_ttl'] = kwargs.get('result_ttl', get_result_ttl(queue_name))
     kwargs['connection'] = connection
     decorator = _rq_job(queue, *args, **kwargs)
     if func:

--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -66,7 +66,7 @@ class DjangoRQ(Queue):
         from .settings import QUEUES
 
         queue_name = kwargs.get('queue_name') or self.name
-        kwargs['result_ttl'] = QUEUES[queue_name].get('DEFAULT_RESULT_TTL')
+        kwargs['result_ttl'] = kwargs.get('result_ttl', QUEUES[queue_name].get('DEFAULT_RESULT_TTL'))
 
         return super(DjangoRQ, self).enqueue_call(*args, **kwargs)
 

--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -66,7 +66,7 @@ class DjangoRQ(Queue):
         from .settings import QUEUES
 
         queue_name = kwargs.get('queue_name') or self.name
-        kwargs['result_ttl'] = kwargs.get('result_ttl', QUEUES[queue_name].get('DEFAULT_RESULT_TTL'))
+        kwargs['result_ttl'] = kwargs.get('result_ttl', get_result_ttl(queue_name))
 
         return super(DjangoRQ, self).enqueue_call(*args, **kwargs)
 
@@ -315,6 +315,16 @@ def get_unique_connection_configs(config=None):
         if value not in connection_configs:
             connection_configs.append(value)
     return connection_configs
+
+
+def get_result_ttl(name: str = 'default'):
+    """
+    Returns the result ttl from RQ_QUEUES if found, otherwise from RQ
+    """
+    from .settings import QUEUES
+
+    RQ = getattr(settings, 'RQ', {})
+    return QUEUES[name].get('DEFAULT_RESULT_TTL', RQ.get('DEFAULT_RESULT_TTL'))
 
 
 """


### PR DESCRIPTION
The PR is fixing issue #705.

Since there are 3 places where the result_ttl can be set, the PR aims to set the order as:
- the decorator `result_ttl`
- the `settiings.RQ_QUEUES[queue_name]['DEFAULT_RESULT_TTL']`.
- the `settings.RQ` DEFAULT_RESULT_TTL, and