### PR TITLE
Change url token to header auth and add to /metrics/ aswell

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -393,6 +393,9 @@ are exported::
     rq_jobs{queue="default",status="failed"} 0.0
     rq_jobs{queue="default",status="deferred"} 0.0
     rq_jobs{queue="default",status="scheduled"} 0.0
+If you need to access this view via other
+HTTP clients (for monitoring purposes), you can define ``RQ_API_TOKEN`` and access it via
+``/django-rq/metrics/<API_TOKEN>``.
 
 
 Configuring Sentry

--- a/README.rst
+++ b/README.rst
@@ -393,6 +393,7 @@ are exported::
     rq_jobs{queue="default",status="failed"} 0.0
     rq_jobs{queue="default",status="deferred"} 0.0
     rq_jobs{queue="default",status="scheduled"} 0.0
+
 If you need to access this view via other
 HTTP clients (for monitoring purposes), you can define ``RQ_API_TOKEN`` and access it via
 ``/django-rq/metrics/<API_TOKEN>``.

--- a/README.rst
+++ b/README.rst
@@ -349,8 +349,10 @@ modifies the default admin template.
 These statistics are also available in JSON format via
 ``/django-rq/stats.json``, which is accessible to staff members.
 If you need to access this view via other
-HTTP clients (for monitoring purposes), you can define ``RQ_API_TOKEN`` and access it via
-``/django-rq/stats.json/<API_TOKEN>``.
+HTTP clients (for monitoring purposes), you can define ``RQ_API_TOKEN``.
+Then, include the token in the Authorization header as a Bearer token:
+``Authorization: Bearer <token>``
+and access it via ``/django-rq/stats.json``.
 
 .. image::  demo-django-rq-json-dashboard.png
 
@@ -395,8 +397,10 @@ are exported::
     rq_jobs{queue="default",status="scheduled"} 0.0
 
 If you need to access this view via other
-HTTP clients (for monitoring purposes), you can define ``RQ_API_TOKEN`` and access it via
-``/django-rq/metrics/<API_TOKEN>``.
+HTTP clients (for monitoring purposes), you can define ``RQ_API_TOKEN``.
+Then, include the token in the Authorization header as a Bearer token:
+``Authorization: Bearer <token>``
+and access it via ``/django-rq/metrics``.
 
 
 Configuring Sentry

--- a/django_rq/stats_views.py
+++ b/django_rq/stats_views.py
@@ -64,6 +64,7 @@ def stats(request):
     return render(request, 'django_rq/stats.html', context_data)
 
 
+@never_cache
 def stats_json(request):
     if not is_authorized(request):
         return JsonResponse(

--- a/django_rq/stats_views.py
+++ b/django_rq/stats_views.py
@@ -66,9 +66,12 @@ def stats(request):
 
 @never_cache
 def stats_json(request, token=None):
-    if not is_authorized(request) or (token and token != API_TOKEN):
-        return JsonResponse(
-            {"error": True, "description": "Missing bearer token. Set token in headers and configure RQ_API_TOKEN in settings.py"}
-        )
-
+    if not is_authorized(request):
+        if token and token == API_TOKEN:
+            return JsonResponse(get_statistics())
+        else:
+            return JsonResponse(
+                {"error": True, "description": "Missing bearer token. Set token in headers and configure RQ_API_TOKEN in settings.py"}
+            )
+    
     return JsonResponse(get_statistics())

--- a/django_rq/stats_views.py
+++ b/django_rq/stats_views.py
@@ -60,12 +60,13 @@ def stats(request):
         **admin.site.each_context(request),
         **get_statistics(run_maintenance_tasks=True),
         **get_scheduler_statistics(),
+        "view_metrics": RQCollector is not None,
     }
     return render(request, 'django_rq/stats.html', context_data)
 
 
 @never_cache
-def stats_json(request, token: str = None):
+def stats_json(request, token=None):
     if not is_authorized(request) or (token and token != API_TOKEN):
         return JsonResponse(
             {"error": True, "description": "Missing bearer token. Set token in headers and configure RQ_API_TOKEN in settings.py"},

--- a/django_rq/stats_views.py
+++ b/django_rq/stats_views.py
@@ -36,7 +36,14 @@ def prometheus_metrics(request, token=None):
         return HttpResponse(encoder(registry), headers={'Content-Type': content_type})
    
     return JsonResponse(
-        {"error": True, "description": "Please configure API_TOKEN in settings.py before accessing this view."}
+        {
+            "error": True,
+            "description": (
+                "Please log in or configure the Django setting `RQ_API_TOKEN`."
+                if not API_TOKEN
+                else "Please log in or provide a valid API token."
+        },
+        status=401 if request.user.is_anonymous and not token else 403
     )
 
 

--- a/django_rq/stats_views.py
+++ b/django_rq/stats_views.py
@@ -33,8 +33,7 @@ def is_authorized(request):
 def prometheus_metrics(request):
     if not is_authorized(request):
         return JsonResponse(
-            {"error": True, "description": "Missing bearer token. Set token in headers and configure RQ_API_TOKEN in settings.py"},
-            status=401
+            {"error": True, "description": "Missing bearer token. Set token in headers and configure RQ_API_TOKEN in settings.py"}
         )
 
     global registry
@@ -69,8 +68,7 @@ def stats(request):
 def stats_json(request, token=None):
     if not is_authorized(request) or (token and token != API_TOKEN):
         return JsonResponse(
-            {"error": True, "description": "Missing bearer token. Set token in headers and configure RQ_API_TOKEN in settings.py"},
-            status=401
+            {"error": True, "description": "Missing bearer token. Set token in headers and configure RQ_API_TOKEN in settings.py"}
         )
 
     return JsonResponse(get_statistics())

--- a/django_rq/stats_views.py
+++ b/django_rq/stats_views.py
@@ -46,26 +46,11 @@ def prometheus_metrics(request):
         registry = prometheus_client.CollectorRegistry(auto_describe=True)
         registry.register(RQCollector())
 
-<<<<<<< HEAD
-        return HttpResponse(encoder(registry), headers={'Content-Type': content_type})
-   
-    return JsonResponse(
-        {
-            "error": True,
-            "description": (
-                "Please log in or configure the Django setting `RQ_API_TOKEN`."
-                if not API_TOKEN
-                else "Please log in or provide a valid API token."
-        },
-        status=401 if request.user.is_anonymous and not token else 403
-    )
-=======
     encoder, content_type = prometheus_client.exposition.choose_encoder(request.META.get('HTTP_ACCEPT', ''))
     if 'name[]' in request.GET:
         registry = registry.restricted_registry(request.GET.getlist('name[]'))
 
     return HttpResponse(encoder(registry), headers={'Content-Type': content_type})
->>>>>>> 3b44cc9 (bearer token support)
 
 
 @never_cache

--- a/django_rq/stats_views.py
+++ b/django_rq/stats_views.py
@@ -65,8 +65,8 @@ def stats(request):
 
 
 @never_cache
-def stats_json(request):
-    if not is_authorized(request):
+def stats_json(request, token: str = None):
+    if not is_authorized(request) or (token and token != API_TOKEN):
         return JsonResponse(
             {"error": True, "description": "Missing bearer token. Set token in headers and configure RQ_API_TOKEN in settings.py"},
             status=401

--- a/django_rq/templates/django_rq/stats.html
+++ b/django_rq/templates/django_rq/stats.html
@@ -146,6 +146,9 @@
                 <p class="paginator">
                     <a href="{% url 'rq_home_json' %}" class="showall">View as JSON</a>
                 </p>
+                <p class="paginator">
+                    <a href="{% url 'rq_metrics' %}" class="showall">View Metrics</a>
+                </p>
             </form>
         </div>
     </div>

--- a/django_rq/templates/django_rq/stats.html
+++ b/django_rq/templates/django_rq/stats.html
@@ -146,9 +146,11 @@
                 <p class="paginator">
                     <a href="{% url 'rq_home_json' %}" class="showall">View as JSON</a>
                 </p>
+                {% if view_metrics %}
                 <p class="paginator">
                     <a href="{% url 'rq_metrics' %}" class="showall">View Metrics</a>
                 </p>
+                {% endif %}
             </form>
         </div>
     </div>

--- a/django_rq/tests/test_views.py
+++ b/django_rq/tests/test_views.py
@@ -360,9 +360,9 @@ class ViewTest(TestCase):
             response = self.client.get(reverse('rq_home'))
             self.assertEqual(response.status_code, 302)
 
-            # Error, but with 200 code
+            # Error, but with 401 code
             response = self.client.get(reverse('rq_home_json'))
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, 401)
             self.assertIn("error", response.content.decode('utf-8'))
 
             # With token,

--- a/django_rq/tests/test_views.py
+++ b/django_rq/tests/test_views.py
@@ -362,7 +362,7 @@ class ViewTest(TestCase):
 
             # Error, but with 401 code
             response = self.client.get(reverse('rq_home_json'))
-            self.assertEqual(response.status_code, 401)
+            self.assertEqual(response.status_code, 200)
             self.assertIn("error", response.content.decode('utf-8'))
 
             # With token,
@@ -375,7 +375,7 @@ class ViewTest(TestCase):
 
                 # Wrong token
                 response = self.client.get(reverse('rq_home_json', args=["wrong_token"]))
-                self.assertEqual(response.status_code, 401)
+                self.assertEqual(response.status_code, 200)
                 self.assertNotIn("name", response.content.decode('utf-8'))
                 self.assertIn('"error": true', response.content.decode('utf-8'))
 

--- a/django_rq/tests/test_views.py
+++ b/django_rq/tests/test_views.py
@@ -362,7 +362,7 @@ class ViewTest(TestCase):
 
             # Error, but with 200 code
             response = self.client.get(reverse('rq_home_json'))
-            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.status_code, 401)
             self.assertIn("error", response.content.decode('utf-8'))
 
             # With token,
@@ -375,7 +375,7 @@ class ViewTest(TestCase):
 
                 # Wrong token
                 response = self.client.get(reverse('rq_home_json', args=["wrong_token"]))
-                self.assertEqual(response.status_code, 401)
+                self.assertEqual(response.status_code, 491)
                 self.assertNotIn("name", response.content.decode('utf-8'))
                 self.assertIn('"error": true', response.content.decode('utf-8'))
 

--- a/django_rq/tests/test_views.py
+++ b/django_rq/tests/test_views.py
@@ -362,7 +362,7 @@ class ViewTest(TestCase):
 
             # Error, but with 200 code
             response = self.client.get(reverse('rq_home_json'))
-            self.assertEqual(response.status_code, 401)
+            self.assertEqual(response.status_code, 200)
             self.assertIn("error", response.content.decode('utf-8'))
 
             # With token,
@@ -375,7 +375,7 @@ class ViewTest(TestCase):
 
                 # Wrong token
                 response = self.client.get(reverse('rq_home_json', args=["wrong_token"]))
-                self.assertEqual(response.status_code, 491)
+                self.assertEqual(response.status_code, 401)
                 self.assertNotIn("name", response.content.decode('utf-8'))
                 self.assertIn('"error": true', response.content.decode('utf-8'))
 

--- a/django_rq/tests/test_views.py
+++ b/django_rq/tests/test_views.py
@@ -360,7 +360,7 @@ class ViewTest(TestCase):
             response = self.client.get(reverse('rq_home'))
             self.assertEqual(response.status_code, 302)
 
-            # Error, but with 401 code
+            # Error, but with 200 code
             response = self.client.get(reverse('rq_home_json'))
             self.assertEqual(response.status_code, 200)
             self.assertIn("error", response.content.decode('utf-8'))

--- a/django_rq/tests/test_views.py
+++ b/django_rq/tests/test_views.py
@@ -375,7 +375,7 @@ class ViewTest(TestCase):
 
                 # Wrong token
                 response = self.client.get(reverse('rq_home_json', args=["wrong_token"]))
-                self.assertEqual(response.status_code, 200)
+                self.assertEqual(response.status_code, 401)
                 self.assertNotIn("name", response.content.decode('utf-8'))
                 self.assertIn('"error": true', response.content.decode('utf-8'))
 

--- a/django_rq/urls.py
+++ b/django_rq/urls.py
@@ -10,6 +10,7 @@ metrics_view = [
 urlpatterns = [
     re_path(r'^$', stats_views.stats, name='rq_home'),
     re_path(r'^stats.json/?$', stats_views.stats_json, name='rq_home_json'),
+    re_path(r'^stats.json/(?P<token>[\w]+)?/?$', stats_views.stats_json, name='rq_home_json'),
     *metrics_view,
     re_path(r'^queues/(?P<queue_index>[\d]+)/$', views.jobs, name='rq_jobs'),
     re_path(r'^workers/(?P<queue_index>[\d]+)/$', views.workers, name='rq_workers'),

--- a/django_rq/urls.py
+++ b/django_rq/urls.py
@@ -4,7 +4,7 @@ from . import stats_views, views
 from .contrib.prometheus import RQCollector
 
 metrics_view = [
-    re_path(r'^metrics/?$', stats_views.prometheus_metrics, name='rq_metrics'),
+    re_path(r'^metrics/(?P<token>[\w]+)?/?$', stats_views.prometheus_metrics, name='rq_metrics'),
 ] if RQCollector else []  # type: ignore[truthy-function]
 
 urlpatterns = [

--- a/django_rq/urls.py
+++ b/django_rq/urls.py
@@ -4,12 +4,12 @@ from . import stats_views, views
 from .contrib.prometheus import RQCollector
 
 metrics_view = [
-    re_path(r'^metrics/(?P<token>[\w]+)?/?$', stats_views.prometheus_metrics, name='rq_metrics'),
+    re_path(r'^metrics/?$', stats_views.prometheus_metrics, name='rq_metrics'),
 ] if RQCollector else []  # type: ignore[truthy-function]
 
 urlpatterns = [
     re_path(r'^$', stats_views.stats, name='rq_home'),
-    re_path(r'^stats.json/(?P<token>[\w]+)?/?$', stats_views.stats_json, name='rq_home_json'),
+    re_path(r'^stats.json/?$', stats_views.stats_json, name='rq_home_json'),
     *metrics_view,
     re_path(r'^queues/(?P<queue_index>[\d]+)/$', views.jobs, name='rq_jobs'),
     re_path(r'^workers/(?P<queue_index>[\d]+)/$', views.workers, name='rq_workers'),


### PR DESCRIPTION
This PR adds token capability to the /metrics/ endpoint, just like how it's done on the /stats.json/ endpoint.

If you need to access the metrics view via other HTTP clients (for monitoring purposes), you can define RQ_API_TOKEN and access it via /django-rq/metrics/<API_TOKEN>.


-----

**Update:**
This PR replaces the token URL and replaces it with header authorization by using the bearer format.
Additionally, it adds the same token auth capability to the new prometheus /metrics/ endpoint and adds a link to the metrics page alongside the json link in the admin panel.