### PR TITLE
Move "View Metrics" inside existing <p>

### DIFF
--- a/django_rq/templates/django_rq/stats.html
+++ b/django_rq/templates/django_rq/stats.html
@@ -145,12 +145,10 @@
                 </div>
                 <p class="paginator">
                     <a href="{% url 'rq_home_json' %}" class="showall">View as JSON</a>
-                </p>
                 {% if view_metrics %}
-                <p class="paginator">
                     <a href="{% url 'rq_metrics' %}" class="showall">View Metrics</a>
-                </p>
                 {% endif %}
+                </p>
             </form>
         </div>
     </div>


### PR DESCRIPTION
Just a small PR to make the two "View as JSON" and "View Metrics" link to be inline instead of seperate rows.