### PR TITLE
Add __version__ to __all__ for explicit re-export

### DIFF
--- a/django_rq/__init__.py
+++ b/django_rq/__init__.py
@@ -6,10 +6,11 @@ from .queues import enqueue, get_queue, get_scheduler
 from .workers import get_worker
 
 __all__ = [
-    "job",
+    "__version__",
     "enqueue",
     "get_connection",
     "get_queue",
     "get_scheduler",
     "get_worker",
+    "job",
 ]


### PR DESCRIPTION
Fixes #703. The __all__ list was missing __version__, which causes mypy to fail with --no-implicit-reexport flag. Also sorted the list alphabetically for consistency.