### PR TITLE
Do not filter SSL_CERT_REQS to solve an issue with Cron Schedulers

### DIFF
--- a/django_rq/connection_utils.py
+++ b/django_rq/connection_utils.py
@@ -102,6 +102,7 @@ def filter_connection_params(queue_params: dict[str, Any]) -> dict[str, Any]:
         'SOCKET_TIMEOUT',
         'SSL',
         'CONNECTION_KWARGS',
+        'SSL_CERT_REQS',
     )
 
     # return {p:v for p,v in queue_params.items() if p in CONNECTION_PARAMS}


### PR DESCRIPTION
Hi there!

This change fixes the following issue I had related to the new CronSchedulers.

Because I'm on Heroku I have to set `SSL_CERT_REQS` to `None`
```
RQ_QUEUES = {
    'default': {
        'URL': get_secret('REDIS_URL') + '/1',
        'SSL_CERT_REQS': None
    },
}
```

However when I acces `/admin/django-rq/` I noticed that my list of Cron Schedulers is empty. Some digging led me to the function `utils.get_cron_schedulers`. This function fails because of `[SSL: CERTIFICATE_VERIFY_FAILED]`. Looking into the connection I noticed that `ssl_cert_reqs=required` was in there. This was strange I thought. Digging some more led me to the function `connection_utils.filter_connection_params` that filtered out my `SSL_CERT_REQS` setting. When I add `SSL_CERT_REQS` to the whitelist it all works as expected and I can see my running scheduler on the Cron Schedulers overview on `admin/django-rq/`.