### PR TITLE
fix Django admin integration including preserving compatibility

### DIFF
--- a/django_rq/admin.py
+++ b/django_rq/admin.py
@@ -53,14 +53,15 @@ class QueueAdmin(admin.ModelAdmin):
             """Wrap view with admin_site.admin_view for permission checking"""
 
             @wraps(view)
-            def wrapper(*args, **kwargs):
-                return self.admin_site.admin_view(view)(*args, **kwargs)
+            def wrapper(request, *args, **kwargs):
+                request.current_app = self.admin_site.name
+                return self.admin_site.admin_view(view)(request, *args, **kwargs)
 
             return wrapper
 
         # Get both sets of URL patterns
-        api_urls = get_api_urlpatterns()  # Not wrapped - have their own auth
-        admin_urls = get_admin_urlpatterns(view_wrapper=wrap)  # Wrapped with admin auth
+        api_urls = get_api_urlpatterns(name_prefix='django_rq_')  # Not wrapped - have their own auth
+        admin_urls = get_admin_urlpatterns(name_prefix='django_rq_', view_wrapper=wrap)  # Wrapped with admin auth
 
         # Combine and add to standard ModelAdmin URLs
         return api_urls + admin_urls + super().get_urls()

--- a/django_rq/cron_views.py
+++ b/django_rq/cron_views.py
@@ -1,4 +1,3 @@
-from django.contrib import admin
 from django.contrib.admin.views.decorators import staff_member_required
 from django.http import Http404
 from django.shortcuts import render
@@ -6,6 +5,7 @@ from django.views.decorators.cache import never_cache
 
 from .connection_utils import get_connection_by_index
 from .cron import DjangoCronScheduler
+from .views import each_context
 
 
 @never_cache
@@ -37,7 +37,7 @@ def cron_scheduler_detail(request, connection_index: int, scheduler_name: str):
             raise Http404(f"Scheduler '{scheduler_name}' not found")
 
         context_data = {
-            **admin.site.each_context(request),
+            **each_context(request),
             "scheduler": scheduler,
         }
 

--- a/django_rq/stats_views.py
+++ b/django_rq/stats_views.py
@@ -2,7 +2,6 @@ from secrets import compare_digest
 
 from typing import Optional
 
-from django.contrib import admin
 from django.contrib.admin.views.decorators import staff_member_required
 from django.http import Http404, HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import render
@@ -10,6 +9,7 @@ from django.views.decorators.cache import never_cache
 
 from . import settings as django_rq_settings
 from .utils import get_cron_schedulers, get_scheduler_statistics, get_statistics
+from .views import each_context
 
 try:
     import prometheus_client
@@ -64,7 +64,7 @@ def prometheus_metrics(request):
 @staff_member_required
 def stats(request: HttpRequest) -> HttpResponse:
     context_data = {
-        **admin.site.each_context(request),
+        **each_context(request),
         **get_statistics(run_maintenance_tasks=True),
         **get_scheduler_statistics(),
         "view_metrics": RQCollector is not None,

--- a/django_rq/templates/django_rq/clear_failed_queue.html
+++ b/django_rq/templates/django_rq/clear_failed_queue.html
@@ -17,8 +17,8 @@
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
-        <a href="{% url 'rq_home' %}">Django RQ</a> &rsaquo;
-        <a href = "{% url 'rq_jobs' queue_index %}">{{ queue.name }}</a> &rsaquo;
+        <a href="{% url url_prefix|add:'home' %}">Django RQ</a> &rsaquo;
+        <a href = "{% url url_prefix|add:'jobs' queue_index %}">{{ queue.name }}</a> &rsaquo;
         Delete All
     </div>
 {% endblock %}
@@ -29,7 +29,7 @@
 
 <div id="content-main">
     <p>
-        Are you sure you want to delete {{ total_jobs }} failed job{{ total_jobs|pluralize }} in the <a href = "{% url 'rq_jobs' queue_index %}">{{ queue.name }}</a> queue?
+        Are you sure you want to delete {{ total_jobs }} failed job{{ total_jobs|pluralize }} in the <a href = "{% url url_prefix|add:'jobs' queue_index %}">{{ queue.name }}</a> queue?
         This action can not be undone.
     </p>
     <form action="" method="post">

--- a/django_rq/templates/django_rq/clear_queue.html
+++ b/django_rq/templates/django_rq/clear_queue.html
@@ -17,8 +17,8 @@
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
-        <a href="{% url 'rq_home' %}">Django RQ</a> &rsaquo;
-        <a href = "{% url 'rq_jobs' queue_index %}">{{ queue.name }}</a> &rsaquo;
+        <a href="{% url url_prefix|add:'home' %}">Django RQ</a> &rsaquo;
+        <a href = "{% url url_prefix|add:'jobs' queue_index %}">{{ queue.name }}</a> &rsaquo;
         Empty
     </div>
 {% endblock %}
@@ -29,7 +29,7 @@
 
 <div id="content-main">
     <p>
-        Are you sure you want to clear the queue <a href = "{% url 'rq_jobs' queue_index %}">{{ queue.name }}</a>?
+        Are you sure you want to clear the queue <a href = "{% url url_prefix|add:'jobs' queue_index %}">{{ queue.name }}</a>?
         This action can not be undone.
     </p>
     <form action="" method="post">

--- a/django_rq/templates/django_rq/confirm_action.html
+++ b/django_rq/templates/django_rq/confirm_action.html
@@ -17,8 +17,8 @@
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
-        <a href="{% url 'rq_home' %}">Django RQ</a> &rsaquo;
-        <a href = "{% url 'rq_jobs' queue_index %}">{{ queue.name }}</a> &rsaquo;
+        <a href="{% url url_prefix|add:'home' %}">Django RQ</a> &rsaquo;
+        <a href = "{% url url_prefix|add:'jobs' queue_index %}">{{ queue.name }}</a> &rsaquo;
         {{ action|capfirst }}
     </div>
 {% endblock %}
@@ -29,14 +29,14 @@
 
 <div id="content-main">
     <p>
-        Are you sure you want to <b>{{ action|capfirst }}</b> the selected jobs from <a href="{% url 'rq_jobs' queue_index %}" target="_blank">{{ queue.name }}</a>? These jobs are selected:
+        Are you sure you want to <b>{{ action|capfirst }}</b> the selected jobs from <a href="{% url url_prefix|add:'jobs' queue_index %}" target="_blank">{{ queue.name }}</a>? These jobs are selected:
     </p>
     <ul>
     {% for job_id in job_ids %}
-        <li><a href="{% url 'rq_job_detail' queue_index job_id %}" target="_blank">{{ job_id }}</a></li>
+        <li><a href="{% url url_prefix|add:'job_detail' queue_index job_id %}" target="_blank">{{ job_id }}</a></li>
     {% endfor %}
     </ul>
-    <form action="{% url 'rq_actions' queue_index %}" method="post">
+    <form action="{% url url_prefix|add:'actions' queue_index %}" method="post">
         {% csrf_token %}
         <div>
             {% for job_id in job_ids %}

--- a/django_rq/templates/django_rq/cron_scheduler_detail.html
+++ b/django_rq/templates/django_rq/cron_scheduler_detail.html
@@ -14,7 +14,7 @@
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
-        <a href="{% url 'rq_home' %}">Django RQ</a> &rsaquo;
+        <a href="{% url url_prefix|add:'home' %}">Django RQ</a> &rsaquo;
         Cron Scheduler: {{ scheduler.name }}
     </div>
 {% endblock %}

--- a/django_rq/templates/django_rq/deferred_jobs.html
+++ b/django_rq/templates/django_rq/deferred_jobs.html
@@ -27,8 +27,8 @@
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
-        <a href="{% url 'rq_home' %}">Django RQ</a> &rsaquo;
-        <a href="{% url 'rq_jobs' queue_index %}">{{ queue.name }}</a>
+        <a href="{% url url_prefix|add:'home' %}">Django RQ</a> &rsaquo;
+        <a href="{% url url_prefix|add:'jobs' queue_index %}">{{ queue.name }}</a>
     </div>
 {% endblock %}
 
@@ -39,7 +39,7 @@
 <div id="content-main">
     <div class="module" id="changelist">
         <div class="changelist-form-container">
-            <form id="changelist-form" action="{% url 'rq_confirm_action' queue_index %}" method="post">
+            <form id="changelist-form" action="{% url url_prefix|add:'confirm_action' queue_index %}" method="post">
                 {% csrf_token %}
                 <div class="actions">
                     <label>Actions:
@@ -109,7 +109,7 @@
                                         <input class="action-select" name="_selected_action" type="checkbox" value="{{ job.id }}">
                                     </td>
                                     <th>
-                                        <a href="{% url 'rq_job_detail' queue_index job.id %}">
+                                        <a href="{% url url_prefix|add:'job_detail' queue_index job.id %}">
                                             {{ job.id }}
                                         </a>
                                     </th>

--- a/django_rq/templates/django_rq/delete_job.html
+++ b/django_rq/templates/django_rq/delete_job.html
@@ -17,9 +17,9 @@
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
-        <a href="{% url 'rq_home' %}">Django RQ</a> &rsaquo;
-        <a href = "{% url 'rq_jobs' queue_index %}">{{ queue.name }}</a> &rsaquo;
-        <a href = "{% url 'rq_job_detail' queue_index job.id %}">{{ job.id }}</a> &rsaquo;
+        <a href="{% url url_prefix|add:'home' %}">Django RQ</a> &rsaquo;
+        <a href = "{% url url_prefix|add:'jobs' queue_index %}">{{ queue.name }}</a> &rsaquo;
+        <a href = "{% url url_prefix|add:'job_detail' queue_index job.id %}">{{ job.id }}</a> &rsaquo;
         Delete
     </div>
 {% endblock %}
@@ -30,7 +30,7 @@
 
 <div id="content-main">
     <p>
-        Are you sure you want to delete <a href = "{% url 'rq_job_detail' queue_index job.id %}">{{ job.id }}</a> from <a href = "{% url 'rq_jobs' queue_index %}">{{ queue.name }}</a>?
+        Are you sure you want to delete <a href = "{% url url_prefix|add:'job_detail' queue_index job.id %}">{{ job.id }}</a> from <a href = "{% url url_prefix|add:'jobs' queue_index %}">{{ queue.name }}</a>?
         This action can not be undone.
     </p>
     <form action="" method="post">

--- a/django_rq/templates/django_rq/failed_jobs.html
+++ b/django_rq/templates/django_rq/failed_jobs.html
@@ -27,8 +27,8 @@
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
-        <a href="{% url 'rq_home' %}">Django RQ</a> &rsaquo;
-        <a href="{% url 'rq_jobs' queue_index %}">{{ queue.name }}</a>
+        <a href="{% url url_prefix|add:'home' %}">Django RQ</a> &rsaquo;
+        <a href="{% url url_prefix|add:'jobs' queue_index %}">{{ queue.name }}</a>
     </div>
 {% endblock %}
 
@@ -38,12 +38,12 @@
 
 <div id="content-main">
     <ul class="object-tools">
-        <li><a href="{% url 'rq_requeue_all' queue_index %}" class="requeuelink">Requeue All</a></li>
-        <li><a href="{% url 'rq_delete_failed_jobs' queue_index %}" class="requeuelink">Delete All</a></li>
+        <li><a href="{% url url_prefix|add:'requeue_all' queue_index %}" class="requeuelink">Requeue All</a></li>
+        <li><a href="{% url url_prefix|add:'delete_failed_jobs' queue_index %}" class="requeuelink">Delete All</a></li>
     </ul>
     <div class="module" id="changelist">
         <div class="changelist-form-container">
-            <form id="changelist-form" action="{% url 'rq_confirm_action' queue_index %}" method="post">
+            <form id="changelist-form" action="{% url url_prefix|add:'confirm_action' queue_index %}" method="post">
                 {% csrf_token %}
                 <div class="actions">
                     <label>Actions:
@@ -115,7 +115,7 @@
                                         <input class="action-select" name="_selected_action" type="checkbox" value="{{ job.id }}">
                                     </td>
                                     <th>
-                                        <a href="{% url 'rq_job_detail' queue_index job.id %}">
+                                        <a href="{% url url_prefix|add:'job_detail' queue_index job.id %}">
                                             {{ job.id }}
                                         </a>
                                     </th>

--- a/django_rq/templates/django_rq/finished_jobs.html
+++ b/django_rq/templates/django_rq/finished_jobs.html
@@ -27,8 +27,8 @@
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
-        <a href="{% url 'rq_home' %}">Django RQ</a> &rsaquo;
-        <a href="{% url 'rq_jobs' queue_index %}">{{ queue.name }}</a>
+        <a href="{% url url_prefix|add:'home' %}">Django RQ</a> &rsaquo;
+        <a href="{% url url_prefix|add:'jobs' queue_index %}">{{ queue.name }}</a>
     </div>
 {% endblock %}
 
@@ -38,12 +38,12 @@
 
 <div id="content-main">
     <ul class="object-tools">
-        <li><a href="{% url 'rq_requeue_all' queue_index %}" class="requeuelink">Requeue All</a></li>
-        <li><a href="{% url 'rq_delete_failed_jobs' queue_index %}" class="requeuelink">Delete All</a></li>
+        <li><a href="{% url url_prefix|add:'requeue_all' queue_index %}" class="requeuelink">Requeue All</a></li>
+        <li><a href="{% url url_prefix|add:'delete_failed_jobs' queue_index %}" class="requeuelink">Delete All</a></li>
     </ul>
     <div class="module" id="changelist">
         <div class="changelist-form-container">
-            <form id="changelist-form" action="{% url 'rq_confirm_action' queue_index %}" method="post">
+            <form id="changelist-form" action="{% url url_prefix|add:'confirm_action' queue_index %}" method="post">
                 {% csrf_token %}
                 <div class="actions">
                     <label>Actions:
@@ -115,7 +115,7 @@
                                         <input class="action-select" name="_selected_action" type="checkbox" value="{{ job.id }}">
                                     </td>
                                     <th>
-                                        <a href="{% url 'rq_job_detail' queue_index job.id %}">
+                                        <a href="{% url url_prefix|add:'job_detail' queue_index job.id %}">
                                             {{ job.id }}
                                         </a>
                                     </th>

--- a/django_rq/templates/django_rq/job_detail.html
+++ b/django_rq/templates/django_rq/job_detail.html
@@ -21,9 +21,9 @@
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
-        <a href="{% url 'rq_home' %}">Django RQ</a> &rsaquo;
-        <a href = "{% url 'rq_jobs' queue_index %}">{{ queue.name }}</a> &rsaquo;
-        <a href = "{% url 'rq_job_detail' queue_index job.id %}">{{ job.id }}</a>
+        <a href="{% url url_prefix|add:'home' %}">Django RQ</a> &rsaquo;
+        <a href = "{% url url_prefix|add:'jobs' queue_index %}">{{ queue.name }}</a> &rsaquo;
+        <a href = "{% url url_prefix|add:'job_detail' queue_index job.id %}">{{ job.id }}</a>
     </div>
 {% endblock %}
 
@@ -190,7 +190,7 @@
                             {% if not forloop.first %}
                                 <br>
                             {% endif %}
-                            <a href = "{% url 'rq_job_detail' queue_index dependency.0 %}">
+                            <a href = "{% url url_prefix|add:'job_detail' queue_index dependency.0 %}">
                                 {% if dependency.1 %}
                                     {{ dependency.1.func_name }}
                                 {% else %}
@@ -232,19 +232,19 @@
     <div class="submit-row">
         <div class="deletelink-box"><a href="delete/" class="deletelink">Delete</a></div>
         {% if job.is_started %}
-            <form method = 'POST' action = "{% url 'rq_stop_job' queue_index job.id %}">
+            <form method = 'POST' action = "{% url url_prefix|add:'stop_job' queue_index job.id %}">
                 {% csrf_token %}
                 <input type="submit" value="Stop" class="deletelink" name="stop">
             </form>
         {% endif %}
         {% if job.is_failed %}
-            <form method = 'POST' action = "{% url 'rq_requeue_job' queue_index job.id %}">
+            <form method = 'POST' action = "{% url url_prefix|add:'requeue_job' queue_index job.id %}">
                 {% csrf_token %}
                 <input type="submit" value="Requeue" class="default" name="requeue">
             </form>
         {% endif %}
         {% if not job.is_queued and not job.is_failed %}
-            <form method = 'POST' action = "{% url 'rq_enqueue_job' queue_index job.id %}">
+            <form method = 'POST' action = "{% url url_prefix|add:'enqueue_job' queue_index job.id %}">
                 {% csrf_token %}
                 <input type="submit" value="Enqueue" class="default" name="Enqueue">
             </form>

--- a/django_rq/templates/django_rq/jobs.html
+++ b/django_rq/templates/django_rq/jobs.html
@@ -27,8 +27,8 @@
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
-        <a href="{% url 'rq_home' %}">Django RQ</a> &rsaquo;
-        <a href="{% url 'rq_jobs' queue_index %}">{{ queue.name }}</a>
+        <a href="{% url url_prefix|add:'home' %}">Django RQ</a> &rsaquo;
+        <a href="{% url url_prefix|add:'jobs' queue_index %}">{{ queue.name }}</a>
     </div>
 {% endblock %}
 
@@ -39,15 +39,15 @@
 <div id="content-main">
     <ul class="object-tools">
         {% if job_status == 'Failed' %}
-            <li><a href="{% url 'rq_requeue_all' queue_index %}" class="requeuelink">Requeue All</a></li>
-            <li><a href="{% url 'rq_delete_failed_jobs' queue_index %}" class="requeuelink">Delete All</a></li>
+            <li><a href="{% url url_prefix|add:'requeue_all' queue_index %}" class="requeuelink">Requeue All</a></li>
+            <li><a href="{% url url_prefix|add:'delete_failed_jobs' queue_index %}" class="requeuelink">Delete All</a></li>
         {% elif job_status == 'Queued' %}
-            <li><a href="{% url 'rq_clear' queue_index %}" class="deletelink">Empty Queue</a></li>
+            <li><a href="{% url url_prefix|add:'clear' queue_index %}" class="deletelink">Empty Queue</a></li>
         {% endif %}
     </ul>
     <div class="module" id="changelist">
         <div class="changelist-form-container">
-            <form id="changelist-form" action="{% url 'rq_confirm_action' queue_index %}" method="post">
+            <form id="changelist-form" action="{% url url_prefix|add:'confirm_action' queue_index %}" method="post">
                 {% csrf_token %}
                 <div class="actions">
                     <label>Actions:
@@ -115,7 +115,7 @@
                                         <input class="action-select" name="_selected_action" type="checkbox" value="{{ job.id }}">
                                     </td>
                                     <th>
-                                        <a href="{% url 'rq_job_detail' queue_index job.id %}">
+                                        <a href="{% url url_prefix|add:'job_detail' queue_index job.id %}">
                                             {{ job.id }}
                                         </a>
                                     </th>

--- a/django_rq/templates/django_rq/requeue_all.html
+++ b/django_rq/templates/django_rq/requeue_all.html
@@ -17,8 +17,8 @@
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
-        <a href="{% url 'rq_home' %}">Django RQ</a> &rsaquo;
-        <a href = "{% url 'rq_jobs' queue_index %}">{{ queue.name }}</a> &rsaquo;
+        <a href="{% url url_prefix|add:'home' %}">Django RQ</a> &rsaquo;
+        <a href = "{% url url_prefix|add:'jobs' queue_index %}">{{ queue.name }}</a> &rsaquo;
         Requeue All
     </div>
 {% endblock %}
@@ -29,7 +29,7 @@
 
 <div id="content-main">
     <p>
-        Are you sure you want to requeue {{ total_jobs }} job{{ total_jobs|pluralize }} in the <a href = "{% url 'rq_jobs' queue_index %}">{{ queue.name }}</a> queue?
+        Are you sure you want to requeue {{ total_jobs }} job{{ total_jobs|pluralize }} in the <a href = "{% url url_prefix|add:'jobs' queue_index %}">{{ queue.name }}</a> queue?
         This action can not be undone.
     </p>
     <form action="" method="post">

--- a/django_rq/templates/django_rq/scheduled_jobs.html
+++ b/django_rq/templates/django_rq/scheduled_jobs.html
@@ -27,8 +27,8 @@
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
-        <a href="{% url 'rq_home' %}">Django RQ</a> &rsaquo;
-        <a href="{% url 'rq_jobs' queue_index %}">{{ queue.name }}</a>
+        <a href="{% url url_prefix|add:'home' %}">Django RQ</a> &rsaquo;
+        <a href="{% url url_prefix|add:'jobs' queue_index %}">{{ queue.name }}</a>
     </div>
 {% endblock %}
 
@@ -39,7 +39,7 @@
 <div id="content-main">
     <div class="module" id="changelist">
         <div class="changelist-form-container">
-            <form id="changelist-form" action="{% url 'rq_confirm_action' queue_index %}" method="post">
+            <form id="changelist-form" action="{% url url_prefix|add:'confirm_action' queue_index %}" method="post">
                 {% csrf_token %}
                 <div class="actions">
                     <label>Actions:
@@ -112,7 +112,7 @@
                                         <input class="action-select" name="_selected_action" type="checkbox" value="{{ job.id }}">
                                     </td>
                                     <th>
-                                        <a href="{% url 'rq_job_detail' queue_index job.id %}">
+                                        <a href="{% url url_prefix|add:'job_detail' queue_index job.id %}">
                                             {{ job.id }}
                                         </a>
                                     </th>

--- a/django_rq/templates/django_rq/scheduler.html
+++ b/django_rq/templates/django_rq/scheduler.html
@@ -27,7 +27,7 @@
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
-        <a href="{% url 'rq_home' %}">Django RQ</a> &rsaquo;
+        <a href="{% url url_prefix|add:'home' %}">Django RQ</a> &rsaquo;
     </div>
 {% endblock %}
 
@@ -78,7 +78,7 @@
                                     <input class="action-select" name="_selected_action" type="checkbox" value="{{ job.id }}">
                                 </td>
                                 <td>
-                                    <a href = "{% url 'rq_job_detail' job.queue_index job.id %}">
+                                    <a href = "{% url url_prefix|add:'job_detail' job.queue_index job.id %}">
                                         {{ job.id }}
                                     </a>
                                 </td>

--- a/django_rq/templates/django_rq/started_job_registry.html
+++ b/django_rq/templates/django_rq/started_job_registry.html
@@ -27,8 +27,8 @@
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
-        <a href="{% url 'rq_home' %}">Django RQ</a> &rsaquo;
-        <a href="{% url 'rq_jobs' queue_index %}">{{ queue.name }}</a>
+        <a href="{% url url_prefix|add:'home' %}">Django RQ</a> &rsaquo;
+        <a href="{% url url_prefix|add:'jobs' queue_index %}">{{ queue.name }}</a>
     </div>
 {% endblock %}
 
@@ -40,7 +40,7 @@
 
     <div class="module" id="changelist">
         <div class="changelist-form-container">
-            <form id="changelist-form" action="{% url 'rq_confirm_action' queue_index %}" method="post">
+            <form id="changelist-form" action="{% url url_prefix|add:'confirm_action' queue_index %}" method="post">
                 {% csrf_token %}
                 <div class="actions">
                     <label>Actions:
@@ -93,7 +93,7 @@
                                         <input class="action-select" name="_selected_action" type="checkbox" value="{{ execution.job.id }}">
                                     </td>
                                     <th>
-                                        <a href="{% url 'rq_job_detail' queue_index execution.job_id %}">
+                                        <a href="{% url url_prefix|add:'job_detail' queue_index execution.job_id %}">
                                             {{ execution.id }}
                                         </a>
                                     </th>

--- a/django_rq/templates/django_rq/stats.html
+++ b/django_rq/templates/django_rq/stats.html
@@ -18,7 +18,7 @@
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
-        <a href="{% url 'rq_home' %}">Django RQ</a>
+        <a href="{% url url_prefix|add:'home' %}">Django RQ</a>
     </div>
 {% endblock %}
 
@@ -93,42 +93,42 @@
                             {% for queue in queues %}
                             <tr class="{% cycle 'row1' 'row2' %}">
                                 <th>
-                                    <a href="{% url 'rq_jobs' queue.index %}">
+                                    <a href="{% url url_prefix|add:'jobs' queue.index %}">
                                         {{ queue.name }}
                                     </a>
                                 </th>
                                 <th>
-                                    <a href="{% url 'rq_jobs' queue.index %}">
+                                    <a href="{% url url_prefix|add:'jobs' queue.index %}">
                                         {{ queue.jobs }}
                                     </a>
                                 </th>
                                 <td>{{ queue.oldest_job_timestamp }}</td>
                                 <th>
-                                    <a href="{% url 'rq_started_jobs' queue.index %}">
+                                    <a href="{% url url_prefix|add:'started_jobs' queue.index %}">
                                         {{ queue.started_jobs }}
                                     </a>
                                 </th>
                                 <th>
-                                    <a href="{% url 'rq_deferred_jobs' queue.index %}">
+                                    <a href="{% url url_prefix|add:'deferred_jobs' queue.index %}">
                                         {{ queue.deferred_jobs }}
                                     </a>
                                 </th>
                                 <th>
-                                    <a href="{% url 'rq_finished_jobs' queue.index %}">
+                                    <a href="{% url url_prefix|add:'finished_jobs' queue.index %}">
                                         {{ queue.finished_jobs }}
                                     </a>
                                 </th>
                                 <th>
-                                    <a href="{% url 'rq_failed_jobs' queue.index %}">
+                                    <a href="{% url url_prefix|add:'failed_jobs' queue.index %}">
                                         {{ queue.failed_jobs }}
                                     </a>
                                 </th>
                                 <th>
-                                    <a href="{% url 'rq_scheduled_jobs' queue.index %}">
+                                    <a href="{% url url_prefix|add:'scheduled_jobs' queue.index %}">
                                         {{ queue.scheduled_jobs }}
                                     </a>
                                 </th>
-                                <th><a href="{% url 'rq_workers' queue.index %}">
+                                <th><a href="{% url url_prefix|add:'workers' queue.index %}">
                                         {{ queue.workers }}
                                     </a>
                                 </th>
@@ -144,9 +144,9 @@
                     </table>
                 </div>
                 <p class="paginator">
-                    <a href="{% url 'rq_home_json' %}" class="showall">View as JSON</a>
+                    <a href="{% url url_prefix|add:'home_json' %}" class="showall">View as JSON</a>
                 {% if view_metrics %}
-                    <a href="{% url 'rq_metrics' %}" class="showall">View Metrics</a>
+                    <a href="{% url url_prefix|add:'metrics' %}" class="showall">View Metrics</a>
                 {% endif %}
                 </p>
             </form>
@@ -171,7 +171,7 @@
                 <tbody>
                     {% for cron_scheduler in cron_schedulers %}
                     <tr class="{% cycle 'row1' 'row2' %}">
-                        <td><a href="{% url 'rq_cron_scheduler_detail' cron_scheduler.connection_index cron_scheduler.name %}">{{ cron_scheduler.name }}</a></td>
+                        <td><a href="{% url url_prefix|add:'cron_scheduler_detail' cron_scheduler.connection_index cron_scheduler.name %}">{{ cron_scheduler.name }}</a></td>
                         <td>{{ cron_scheduler.connection.connection_pool.connection_kwargs.host }}</td>
                         <td>{{ cron_scheduler.connection.connection_pool.connection_kwargs.port }}</td>
                         <td>{{ cron_scheduler.connection.connection_pool.connection_kwargs.db }}</td>
@@ -196,8 +196,8 @@
         </thead>
         {% for connection, scheduler in schedulers.items %}
         <tr class="{% cycle 'row1' 'row2' %}">
-            <td><a href="{% url 'rq_scheduler_jobs' scheduler.index %}">{{ connection }}</a></td>
-            <td><a href="{% url 'rq_scheduler_jobs' scheduler.index %}">{{ scheduler.count }}</a></td>
+            <td><a href="{% url url_prefix|add:'scheduler_jobs' scheduler.index %}">{{ connection }}</a></td>
+            <td><a href="{% url url_prefix|add:'scheduler_jobs' scheduler.index %}">{{ scheduler.count }}</a></td>
         </tr>
         {% endfor %}
     </table>

--- a/django_rq/templates/django_rq/worker_details.html
+++ b/django_rq/templates/django_rq/worker_details.html
@@ -19,9 +19,9 @@
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
-        <a href="{% url 'rq_home' %}">Django RQ</a> &rsaquo;
-        <a href = "{% url 'rq_workers' queue_index %}">{{ queue.name }} Workers</a> &rsaquo;
-        <a href = "{% url 'rq_worker_details' queue_index worker.name %}">{{ worker.name }}</a>
+        <a href="{% url url_prefix|add:'home' %}">Django RQ</a> &rsaquo;
+        <a href = "{% url url_prefix|add:'workers' queue_index %}">{{ queue.name }} Workers</a> &rsaquo;
+        <a href = "{% url url_prefix|add:'worker_details' queue_index worker.name %}">{{ worker.name }}</a>
     </div>
 {% endblock %}
 
@@ -74,7 +74,7 @@
                 <label class="required">Current Job:</label>
                 <div class="data">
                     {{ job.func_name }}
-                    (<a href = "{% url 'rq_job_detail' queue_index job.id %}">{{ job.id }}</a>)
+                    (<a href = "{% url url_prefix|add:'job_detail' queue_index job.id %}">{{ job.id }}</a>)
                 </div>
             </div>
         </div>

--- a/django_rq/templates/django_rq/workers.html
+++ b/django_rq/templates/django_rq/workers.html
@@ -27,8 +27,8 @@
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
-        <a href="{% url 'rq_home' %}">Django RQ</a> &rsaquo;
-        <a href = "{% url 'rq_jobs' queue_index %}">{{ queue.name }} Workers</a>
+        <a href="{% url url_prefix|add:'home' %}">Django RQ</a> &rsaquo;
+        <a href = "{% url url_prefix|add:'jobs' queue_index %}">{{ queue.name }} Workers</a>
     </div>
 {% endblock %}
 
@@ -38,7 +38,7 @@
 
 <div id="content-main">
     <div class="module" id="changelist">
-        <form id="changelist-form" action="{% url 'rq_confirm_action' queue_index %}" method="post">
+        <form id="changelist-form" action="{% url url_prefix|add:'confirm_action' queue_index %}" method="post">
             {% csrf_token %}
             <div class="results">
                 <table id="result_list">
@@ -54,7 +54,7 @@
                         {% for worker in workers %}
                             <tr class = "{% cycle 'row1' 'row2' %}">
                                 <th>
-                                    <a href = '{% url 'rq_worker_details' queue_index worker.key %}'>
+                                    <a href = '{% url url_prefix|add:'worker_details' queue_index worker.key %}'>
                                         {{ worker.name }}
                                     </a>
                                 </th>

--- a/django_rq/urls.py
+++ b/django_rq/urls.py
@@ -6,7 +6,7 @@ from . import cron_views, stats_views, views
 from .contrib.prometheus import RQCollector
 
 
-def get_api_urlpatterns() -> list[URLPattern]:
+def get_api_urlpatterns(name_prefix: str = '') -> list[URLPattern]:
     """
     Get URL patterns for views that have their own authentication (API tokens).
 
@@ -19,7 +19,7 @@ def get_api_urlpatterns() -> list[URLPattern]:
     # Conditional metrics view (only if prometheus_client is installed)
     metrics_view = (
         [
-            re_path(r'^metrics/?$', stats_views.prometheus_metrics, name='rq_metrics'),
+            re_path(r'^metrics/?$', stats_views.prometheus_metrics, name=f'{name_prefix}metrics'),
         ]
         if RQCollector is not None
         else []
@@ -27,14 +27,14 @@ def get_api_urlpatterns() -> list[URLPattern]:
 
     return [
         # Stats JSON (supports API token authentication)
-        re_path(r'^stats.json/?$', stats_views.stats_json, name='rq_home_json'),
-        re_path(r'^stats.json/(?P<token>[\w]+)?/?$', stats_views.stats_json, name='rq_home_json'),
+        re_path(r'^stats.json/?$', stats_views.stats_json, name=f'{name_prefix}home_json'),
+        re_path(r'^stats.json/(?P<token>[\w]+)?/?$', stats_views.stats_json, name=f'{name_prefix}home_json'),
         # Prometheus metrics (supports API token authentication)
         *metrics_view,
     ]
 
 
-def get_admin_urlpatterns(view_wrapper: Optional[Callable] = None) -> list[URLPattern]:
+def get_admin_urlpatterns(name_prefix: str = '', view_wrapper: Optional[Callable] = None) -> list[URLPattern]:
     """
     Get URL patterns for views that should be wrapped with admin authentication.
 
@@ -51,39 +51,40 @@ def get_admin_urlpatterns(view_wrapper: Optional[Callable] = None) -> list[URLPa
 
     return [
         # Dashboard
-        path('', maybe_wrap(stats_views.stats), name='rq_home'),
+        path('', maybe_wrap(stats_views.stats), name=f'{name_prefix}home'),
         # Queue views
-        path('queues/<int:queue_index>/', maybe_wrap(views.jobs), name='rq_jobs'),
-        path('queues/<int:queue_index>/finished/', maybe_wrap(views.finished_jobs), name='rq_finished_jobs'),
-        path('queues/<int:queue_index>/failed/', maybe_wrap(views.failed_jobs), name='rq_failed_jobs'),
-        path('queues/<int:queue_index>/failed/clear/', maybe_wrap(views.delete_failed_jobs), name='rq_delete_failed_jobs'),
-        path('queues/<int:queue_index>/scheduled/', maybe_wrap(views.scheduled_jobs), name='rq_scheduled_jobs'),
-        path('queues/<int:queue_index>/started/', maybe_wrap(views.started_jobs), name='rq_started_jobs'),
-        path('queues/<int:queue_index>/deferred/', maybe_wrap(views.deferred_jobs), name='rq_deferred_jobs'),
-        path('queues/<int:queue_index>/empty/', maybe_wrap(views.clear_queue), name='rq_clear'),
-        path('queues/<int:queue_index>/requeue-all/', maybe_wrap(views.requeue_all), name='rq_requeue_all'),
+        path('queues/<int:queue_index>/', maybe_wrap(views.jobs), name=f'{name_prefix}jobs'),
+        path('queues/<int:queue_index>/finished/', maybe_wrap(views.finished_jobs), name=f'{name_prefix}finished_jobs'),
+        path('queues/<int:queue_index>/failed/', maybe_wrap(views.failed_jobs), name=f'{name_prefix}failed_jobs'),
+        path('queues/<int:queue_index>/failed/clear/', maybe_wrap(views.delete_failed_jobs), name=f'{name_prefix}delete_failed_jobs'),
+        path('queues/<int:queue_index>/scheduled/', maybe_wrap(views.scheduled_jobs), name=f'{name_prefix}scheduled_jobs'),
+        path('queues/<int:queue_index>/started/', maybe_wrap(views.started_jobs), name=f'{name_prefix}started_jobs'),
+        path('queues/<int:queue_index>/deferred/', maybe_wrap(views.deferred_jobs), name=f'{name_prefix}deferred_jobs'),
+        path('queues/<int:queue_index>/empty/', maybe_wrap(views.clear_queue), name=f'{name_prefix}clear'),
+        path('queues/<int:queue_index>/requeue-all/', maybe_wrap(views.requeue_all), name=f'{name_prefix}requeue_all'),
         # Job detail and actions
-        path('queues/<int:queue_index>/<str:job_id>/', maybe_wrap(views.job_detail), name='rq_job_detail'),
-        path('queues/<int:queue_index>/<str:job_id>/delete/', maybe_wrap(views.delete_job), name='rq_delete_job'),
-        path('queues/<int:queue_index>/<str:job_id>/requeue/', maybe_wrap(views.requeue_job_view), name='rq_requeue_job'),
-        path('queues/<int:queue_index>/<str:job_id>/enqueue/', maybe_wrap(views.enqueue_job), name='rq_enqueue_job'),
-        path('queues/<int:queue_index>/<str:job_id>/stop/', maybe_wrap(views.stop_job), name='rq_stop_job'),
+        path('queues/<int:queue_index>/<str:job_id>/', maybe_wrap(views.job_detail), name=f'{name_prefix}job_detail'),
+        path('queues/<int:queue_index>/<str:job_id>/delete/', maybe_wrap(views.delete_job), name=f'{name_prefix}delete_job'),
+        path('queues/<int:queue_index>/<str:job_id>/requeue/', maybe_wrap(views.requeue_job_view), name=f'{name_prefix}requeue_job'),
+        path('queues/<int:queue_index>/<str:job_id>/enqueue/', maybe_wrap(views.enqueue_job), name=f'{name_prefix}enqueue_job'),
+        path('queues/<int:queue_index>/<str:job_id>/stop/', maybe_wrap(views.stop_job), name=f'{name_prefix}stop_job'),
         # Bulk actions
-        path('queues/confirm-action/<int:queue_index>/', maybe_wrap(views.confirm_action), name='rq_confirm_action'),
-        path('queues/actions/<int:queue_index>/', maybe_wrap(views.actions), name='rq_actions'),
+        path('queues/confirm-action/<int:queue_index>/', maybe_wrap(views.confirm_action), name=f'{name_prefix}confirm_action'),
+        path('queues/actions/<int:queue_index>/', maybe_wrap(views.actions), name=f'{name_prefix}actions'),
         # Workers
-        path('workers/<int:queue_index>/', maybe_wrap(views.workers), name='rq_workers'),
-        path('workers/<int:queue_index>/<str:key>/', maybe_wrap(views.worker_details), name='rq_worker_details'),
+        path('workers/<int:queue_index>/', maybe_wrap(views.workers), name=f'{name_prefix}workers'),
+        path('workers/<int:queue_index>/<str:key>/', maybe_wrap(views.worker_details), name=f'{name_prefix}worker_details'),
         # Schedulers
-        path('schedulers/<int:scheduler_index>/', maybe_wrap(views.scheduler_jobs), name='rq_scheduler_jobs'),
+        path('schedulers/<int:scheduler_index>/', maybe_wrap(views.scheduler_jobs), name=f'{name_prefix}scheduler_jobs'),
         path(
             'cron-schedulers/<int:connection_index>/<str:scheduler_name>/',
             maybe_wrap(cron_views.cron_scheduler_detail),
-            name='rq_cron_scheduler_detail',
+            name=f'{name_prefix}cron_scheduler_detail',
         ),
     ]
 
 
 # Standalone URL patterns (for use with include('django_rq.urls'))
 # Combines both API and admin patterns without wrapping
+app_name = "django_rq"
 urlpatterns = get_api_urlpatterns() + get_admin_urlpatterns()

--- a/tests/default_with_custom_mount_urls.py
+++ b/tests/default_with_custom_mount_urls.py
@@ -1,0 +1,8 @@
+from django.urls import include, path
+
+from .urls import urlpatterns as default_urls
+
+urlpatterns = [
+    *default_urls,
+    path("django-rq", include("django_rq.urls")),
+]

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from django.contrib.auth.models import User
 from django.core.management import call_command
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.test.client import Client
 from django.urls import reverse
 from rq.cron import CronJob
@@ -168,6 +168,7 @@ class CronCommandTest(TestCase):
         self.assertIn("Starting cron scheduler with 2 jobs...", output)
 
 
+@override_settings(ROOT_URLCONF='tests.default_with_custom_mount_urls')
 class CronViewTest(TestCase):
     def setUp(self):
         """Set up test user and client."""
@@ -182,23 +183,24 @@ class CronViewTest(TestCase):
         scheduler.register(say_hello, "default", interval=60)
         scheduler.register_birth()
 
-        # Test 1: Successful view of existing scheduler
-        connection_index = scheduler.connection_index
-        url = reverse('rq_cron_scheduler_detail', args=[connection_index, 'test-scheduler'])
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.context['scheduler'].name, 'test-scheduler')
-        self.assertContains(response, 'test-scheduler')
+        for prefix in ('admin:django_rq_', 'django_rq:'):
+            # Test 1: Successful view of existing scheduler
+            connection_index = scheduler.connection_index
+            url = reverse(f'{prefix}cron_scheduler_detail', args=[connection_index, 'test-scheduler'])
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.context['scheduler'].name, 'test-scheduler')
+            self.assertContains(response, 'test-scheduler')
 
-        # Test 2: Non-existent scheduler returns 404
-        url = reverse('rq_cron_scheduler_detail', args=[connection_index, 'nonexistent-scheduler'])
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
+            # Test 2: Non-existent scheduler returns 404
+            url = reverse(f'{prefix}cron_scheduler_detail', args=[connection_index, 'nonexistent-scheduler'])
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 404)
 
-        # Test 3: Invalid connection index returns 404
-        url = reverse('rq_cron_scheduler_detail', args=[999, 'test-scheduler'])
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 404)
+            # Test 3: Invalid connection index returns 404
+            url = reverse(f'{prefix}cron_scheduler_detail', args=[999, 'test-scheduler'])
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, 404)
 
         # Clean up
         scheduler.register_death()

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,13 +1,10 @@
 from django.contrib import admin
 from django.urls import path
 
-from django_rq.urls import urlpatterns as django_rq_urlpatterns
-
 from . import views
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('success/', views.success, name='success'),
     path('error/', views.error, name='error'),
-    path('django-rq/', (django_rq_urlpatterns, '', 'django_rq')),
 ]


### PR DESCRIPTION
This change fixes the Django admin integration added in https://github.com/rq/django-rq/pull/747. As is, the integration adds the views, but they do not reverse properly without also including the URLs via `include("django_rq.urls")`. When using Django's `ModelAdmin`, the URLs registered will be in the "admin" namespace, but the templates were not updated to include a namespace so they fail to resolve.

This change conditionally resolves with either the prefix `django_rq:` or `admin:django_rq_` depending on how the view is called (via the admin app or not) and the URLs are also registered with the corresponding prefix.

In order to properly test this integration, the default URL conf has been updated to not include the django_rq URLS via `include`, and a separate `default_with_custom_mount_urls` URL conf is provided in order to test integrations using both `include` and the admin integration.