### PR TITLE
Fix deferred jobs sorting by using get_jobs() utility

### DIFF
--- a/django_rq/views.py
+++ b/django_rq/views.py
@@ -301,11 +301,7 @@ def deferred_jobs(request: HttpRequest, queue_index: int) -> HttpResponse:
         page_range = list(range(1, last_page + 1))
         offset = items_per_page * (page - 1)
         job_ids = registry.get_job_ids(offset, offset + items_per_page - 1, desc=sort_direction == 'descending')
-        for job_id in job_ids:
-            try:
-                jobs.append(Job.fetch(job_id, connection=queue.connection, serializer=queue.serializer))
-            except NoSuchJobError:
-                pass
+        jobs = get_jobs(queue, job_ids, registry)
 
     else:
         page_range = []


### PR DESCRIPTION
The deferred_jobs view was fetching jobs individually in a loop with Job.fetch(), which didn't preserve the sorted order from Redis. All other registry views (finished, failed, scheduled) use the get_jobs() utility which calls Job.fetch_many() and maintains sort order.

Fixes #768