### PR TITLE
Add django-unfold support via django-rq[unfold] extra

### DIFF
--- a/django_rq/templates/django_rq/clear_failed_queue.html
+++ b/django_rq/templates/django_rq/clear_failed_queue.html
@@ -4,21 +4,16 @@
 
 {% block extrastyle %}
     {{ block.super }}
-    <style>
-        .data {
-            display: inline-block;
-            float: left;
-            width: 80%;
-        }
-    </style>
+    {% if not unfold_installed %}
     <link href="{% static 'admin/css/forms.css' %}" type="text/css" rel="stylesheet">
+    {% endif %}
 {% endblock %}
 
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
         <a href="{% rq_url 'home' %}">Django RQ</a> &rsaquo;
-        <a href = "{% rq_url 'jobs' queue_index %}">{{ queue.name }}</a> &rsaquo;
+        <a href="{% rq_url 'jobs' queue_index %}">{{ queue.name }}</a> &rsaquo;
         Delete All
     </div>
 {% endblock %}
@@ -27,9 +22,23 @@
 
 {% block content %}
 
+{% if unfold_installed %}
+<h1 class="font-semibold mb-6 text-xl text-font-important-light dark:text-font-important-dark">Are you sure?</h1>
+<div class="border border-base-200 dark:border-base-800 rounded-default overflow-hidden mb-8">
+    <p class="p-4 text-sm">
+        Are you sure you want to delete {{ total_jobs }} failed job{{ total_jobs|pluralize }} in the
+        <a href="{% rq_url 'jobs' queue_index %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400">{{ queue.name }}</a> queue?
+        This action can not be undone.
+    </p>
+    <form action="" method="post" class="border-t border-base-200 dark:border-base-800 px-4 py-3">
+        {% csrf_token %}
+        <button type="submit" class="bg-red-600 cursor-pointer font-medium hover:bg-red-500 px-3 py-2 rounded-default text-sm text-white">Yes, I'm sure</button>
+    </form>
+</div>
+{% else %}
 <div id="content-main">
     <p>
-        Are you sure you want to delete {{ total_jobs }} failed job{{ total_jobs|pluralize }} in the <a href = "{% rq_url 'jobs' queue_index %}">{{ queue.name }}</a> queue?
+        Are you sure you want to delete {{ total_jobs }} failed job{{ total_jobs|pluralize }} in the <a href="{% rq_url 'jobs' queue_index %}">{{ queue.name }}</a> queue?
         This action can not be undone.
     </p>
     <form action="" method="post">
@@ -39,5 +48,6 @@
         </div>
     </form>
 </div>
+{% endif %}
 
 {% endblock %}

--- a/django_rq/templates/django_rq/clear_queue.html
+++ b/django_rq/templates/django_rq/clear_queue.html
@@ -4,21 +4,16 @@
 
 {% block extrastyle %}
     {{ block.super }}
-    <style>
-        .data {
-            display: inline-block;
-            float: left;
-            width: 80%;
-        }
-    </style>
+    {% if not unfold_installed %}
     <link href="{% static 'admin/css/forms.css' %}" type="text/css" rel="stylesheet">
+    {% endif %}
 {% endblock %}
 
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
         <a href="{% rq_url 'home' %}">Django RQ</a> &rsaquo;
-        <a href = "{% rq_url 'jobs' queue_index %}">{{ queue.name }}</a> &rsaquo;
+        <a href="{% rq_url 'jobs' queue_index %}">{{ queue.name }}</a> &rsaquo;
         Empty
     </div>
 {% endblock %}
@@ -27,9 +22,22 @@
 
 {% block content %}
 
+{% if unfold_installed %}
+<h1 class="font-semibold mb-6 text-xl text-font-important-light dark:text-font-important-dark">Are you sure?</h1>
+<div class="border border-base-200 dark:border-base-800 rounded-default overflow-hidden mb-8">
+    <p class="p-4 text-sm">
+        Are you sure you want to clear the queue <a href="{% rq_url 'jobs' queue_index %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400">{{ queue.name }}</a>?
+        This action can not be undone.
+    </p>
+    <form action="" method="post" class="border-t border-base-200 dark:border-base-800 px-4 py-3">
+        {% csrf_token %}
+        <button type="submit" class="bg-red-600 cursor-pointer font-medium hover:bg-red-500 px-3 py-2 rounded-default text-sm text-white">Yes, I'm sure</button>
+    </form>
+</div>
+{% else %}
 <div id="content-main">
     <p>
-        Are you sure you want to clear the queue <a href = "{% rq_url 'jobs' queue_index %}">{{ queue.name }}</a>?
+        Are you sure you want to clear the queue <a href="{% rq_url 'jobs' queue_index %}">{{ queue.name }}</a>?
         This action can not be undone.
     </p>
     <form action="" method="post">
@@ -39,5 +47,6 @@
         </div>
     </form>
 </div>
+{% endif %}
 
 {% endblock %}

--- a/django_rq/templates/django_rq/confirm_action.html
+++ b/django_rq/templates/django_rq/confirm_action.html
@@ -4,21 +4,16 @@
 
 {% block extrastyle %}
     {{ block.super }}
-    <style>
-        .data {
-            display: inline-block;
-            float: left;
-            width: 80%;
-        }
-    </style>
+    {% if not unfold_installed %}
     <link href="{% static 'admin/css/forms.css' %}" type="text/css" rel="stylesheet">
+    {% endif %}
 {% endblock %}
 
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
         <a href="{% rq_url 'home' %}">Django RQ</a> &rsaquo;
-        <a href = "{% rq_url 'jobs' queue_index %}">{{ queue.name }}</a> &rsaquo;
+        <a href="{% rq_url 'jobs' queue_index %}">{{ queue.name }}</a> &rsaquo;
         {{ action|capfirst }}
     </div>
 {% endblock %}
@@ -27,6 +22,32 @@
 
 {% block content %}
 
+{% if unfold_installed %}
+<h1 class="font-semibold mb-6 text-xl text-font-important-light dark:text-font-important-dark">Are you sure?</h1>
+<div class="border border-base-200 dark:border-base-800 rounded-default overflow-hidden mb-8">
+    <p class="p-4 text-sm">
+        Are you sure you want to <strong>{{ action|capfirst }}</strong> the selected jobs from
+        <a href="{% rq_url 'jobs' queue_index %}" target="_blank" class="text-primary-600 hover:text-primary-500 dark:text-primary-400">{{ queue.name }}</a>?
+        These jobs are selected:
+    </p>
+    <ul class="border-t border-base-200 dark:border-base-800 px-4 py-3 space-y-1">
+        {% for job_id in job_ids %}
+        <li class="text-sm">
+            <a href="{% rq_url 'job_detail' queue_index job_id %}" target="_blank" class="text-primary-600 hover:text-primary-500 dark:text-primary-400">{{ job_id }}</a>
+        </li>
+        {% endfor %}
+    </ul>
+    <form action="{% rq_url 'actions' queue_index %}" method="post" class="border-t border-base-200 dark:border-base-800 px-4 py-3 flex gap-2">
+        {% csrf_token %}
+        {% for job_id in job_ids %}
+            <input type="hidden" name="job_ids" value="{{ job_id }}">
+        {% endfor %}
+        <input type="hidden" name="action" value="{{ action }}" />
+        <input type="hidden" name="next_url" value="{{ next_url }}" />
+        <button type="submit" class="bg-primary-600 cursor-pointer font-medium hover:bg-primary-500 px-3 py-2 rounded-default text-sm text-white">Yes, I'm sure</button>
+    </form>
+</div>
+{% else %}
 <div id="content-main">
     <p>
         Are you sure you want to <b>{{ action|capfirst }}</b> the selected jobs from <a href="{% rq_url 'jobs' queue_index %}" target="_blank">{{ queue.name }}</a>? These jobs are selected:
@@ -48,5 +69,6 @@
         </div>
     </form>
 </div>
+{% endif %}
 
 {% endblock %}

--- a/django_rq/templates/django_rq/cron_scheduler_detail.html
+++ b/django_rq/templates/django_rq/cron_scheduler_detail.html
@@ -4,8 +4,10 @@
 
 {% block extrastyle %}
     {{ block.super }}
+    {% if not unfold_installed %}
     <link rel="stylesheet" href="{% static 'admin/css/forms.css' %}">
     <link rel="stylesheet" href="{% static 'admin/css/changelists.css' %}">
+    {% endif %}
 {% endblock %}
 
 {% block title %}Cron Scheduler: {{ scheduler.name }}{% endblock %}
@@ -21,8 +23,90 @@
 {% endblock %}
 
 {% block content %}
-<div id="content-main">
 
+{% if unfold_installed %}
+
+<h1 class="font-semibold mb-4 text-xl text-font-important-light dark:text-font-important-dark">Cron Scheduler: {{ scheduler.name }}</h1>
+
+<div class="border border-base-200 dark:border-base-800 rounded-default mb-6 overflow-hidden">
+    <div class="flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-36 text-font-default-light dark:text-font-default-dark text-sm">Name</span>
+        <span class="text-sm">{{ scheduler.name }}</span>
+    </div>
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-36 text-font-default-light dark:text-font-default-dark text-sm">Hostname</span>
+        <span class="text-sm">{{ scheduler.hostname }}</span>
+    </div>
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-36 text-font-default-light dark:text-font-default-dark text-sm">PID</span>
+        <span class="text-sm">{{ scheduler.pid }}</span>
+    </div>
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-36 text-font-default-light dark:text-font-default-dark text-sm">Created At</span>
+        <span class="text-sm">{% if scheduler.created_at %}{{ scheduler.created_at|to_localtime|date:"Y-m-d, H:i:s" }}{% else %}-{% endif %}</span>
+    </div>
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-36 text-font-default-light dark:text-font-default-dark text-sm">Last Heartbeat</span>
+        <span class="text-sm">{% if scheduler.last_heartbeat %}{{ scheduler.last_heartbeat|to_localtime|date:"Y-m-d, H:i:s" }}{% else %}-{% endif %}</span>
+    </div>
+    {% if scheduler.config_file %}
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-36 text-font-default-light dark:text-font-default-dark text-sm">Config File</span>
+        <span class="text-sm font-mono">{{ scheduler.config_file }}</span>
+    </div>
+    {% endif %}
+</div>
+
+<h2 class="font-semibold mb-4 text-base text-font-important-light dark:text-font-important-dark">Cron Jobs</h2>
+
+{% if cron_jobs %}
+<div class="overflow-x-auto rounded-default border border-base-200 dark:border-base-800 mb-8">
+    <table class="w-full">
+        <thead class="bg-base-100 dark:bg-base-800">
+            <tr>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Callable</th>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Queue</th>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Schedule</th>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Next Enqueue</th>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Latest Enqueue</th>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Args</th>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Kwargs</th>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Meta</th>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Options</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for cron_job in cron_jobs %}
+            <tr class="border-t border-base-200 dark:border-base-800 hover:bg-base-50 dark:hover:bg-base-800/50">
+                <td class="p-3 px-4 text-sm font-mono text-xs">{{ cron_job.func_name|default:"-" }}</td>
+                <td class="p-3 px-4 text-sm">{{ cron_job.queue_name|default:"-" }}</td>
+                <td class="p-3 px-4 text-sm font-mono text-xs">{{ cron_job.schedule }}</td>
+                <td class="p-3 px-4 text-sm whitespace-nowrap">
+                    {% if cron_job.next_enqueue_time %}{{ cron_job.next_enqueue_time|to_localtime|date:"Y-m-d, H:i:s" }}{% else %}-{% endif %}
+                </td>
+                <td class="p-3 px-4 text-sm whitespace-nowrap">
+                    {% if cron_job.latest_enqueue_time %}{{ cron_job.latest_enqueue_time|to_localtime|date:"Y-m-d, H:i:s" }}{% else %}-{% endif %}
+                </td>
+                <td class="p-3 px-4 text-sm font-mono text-xs">{{ cron_job.args|default_if_none:"-" }}</td>
+                <td class="p-3 px-4 text-sm font-mono text-xs">{{ cron_job.kwargs|default_if_none:"-" }}</td>
+                <td class="p-3 px-4 text-sm font-mono text-xs">{{ cron_job.meta|default_if_none:"-" }}</td>
+                <td class="p-3 px-4 text-sm">
+                    {% for option in cron_job.options %}
+                        <span class="font-mono text-xs">{{ option }}</span>{% if not forloop.last %}<br>{% endif %}
+                    {% empty %}-{% endfor %}
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% else %}
+<p class="mb-8 text-sm text-font-default-light dark:text-font-default-dark">No persisted cron jobs found</p>
+{% endif %}
+
+{% else %}
+
+<div id="content-main">
     <fieldset class="module aligned">
 
         <div class="form-row">
@@ -83,16 +167,8 @@
         </div>
 
         {% if scheduler.config_file %}
-        <div class="form-row">
-            <div>
-                <div class="flex-container">
-                    <label>Config File:</label>
-                    <div class="readonly">{{ scheduler.config_file }}</div>
-                </div>
-            </div>
-        </div>
+        <div class="form-row"><div><div class="flex-container"><label>Config File:</label><div class="readonly">{{ scheduler.config_file }}</div></div></div></div>
         {% endif %}
-
     </fieldset>
 
     <div class="module" id="changelist">
@@ -136,13 +212,7 @@
                         <td>{{ cron_job.args|default_if_none:"-" }}</td>
                         <td>{{ cron_job.kwargs|default_if_none:"-" }}</td>
                         <td>{{ cron_job.meta|default_if_none:"-" }}</td>
-                        <td>
-                            {% for option in cron_job.options %}
-                                {{ option }}{% if not forloop.last %}<br>{% endif %}
-                            {% empty %}
-                                -
-                            {% endfor %}
-                        </td>
+                        <td>{% for option in cron_job.options %}{{ option }}{% if not forloop.last %}<br>{% endif %}{% empty %}-{% endfor %}</td>
                     </tr>
                     {% endfor %}
                 </tbody>
@@ -152,6 +222,8 @@
             {% endif %}
         </div>
     </div>
-
 </div>
+
+{% endif %}
+
 {% endblock %}

--- a/django_rq/templates/django_rq/deferred_jobs.html
+++ b/django_rq/templates/django_rq/deferred_jobs.html
@@ -67,7 +67,6 @@
                     </th>
                     <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Status</th>
                     <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Callable</th>
-                    {% block extra_columns %}{% endblock extra_columns %}
                 </tr>
             </thead>
             <tbody>
@@ -84,7 +83,6 @@
                     </td>
                     <td class="p-3 px-4 text-sm">{{ job.get_status.value }}</td>
                     <td class="p-3 px-4 text-sm font-mono text-xs">{{ job|show_func_name }}</td>
-                    {% block extra_columns_values %}{% endblock extra_columns_values %}
                 </tr>
                 {% endfor %}
             </tbody>

--- a/django_rq/templates/django_rq/deferred_jobs.html
+++ b/django_rq/templates/django_rq/deferred_jobs.html
@@ -6,7 +6,9 @@
 
 {% block extrastyle %}
     {{ block.super }}
+    {% if not unfold_installed %}
     <link rel="stylesheet" type="text/css" href="{% static "admin/css/changelists.css" %}">
+    {% endif %}
 {% endblock %}
 
 {% block extrahead %}
@@ -23,7 +25,6 @@
     </script>
 {% endblock %}
 
-
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
@@ -36,6 +37,73 @@
 
 {% block content %}
 
+{% if unfold_installed %}
+
+<h1 class="font-semibold mb-4 text-xl text-font-important-light dark:text-font-important-dark">Deferred jobs in {{ queue.name }}</h1>
+
+<form id="changelist-form" action="{% rq_url 'confirm_action' queue_index %}" method="post">
+    {% csrf_token %}
+    <div class="flex gap-2 items-center mb-4">
+        <select name="action" class="border border-base-200 dark:border-base-800 rounded-default bg-white dark:bg-base-900 px-3 py-2 text-sm" required>
+            <option value="" selected>---------</option>
+            <option value="delete">Delete</option>
+        </select>
+        <button type="submit" class="bg-primary-600 cursor-pointer font-medium hover:bg-primary-500 px-3 py-2 rounded-default text-sm text-white" name="index" value="0">Go</button>
+    </div>
+    <div class="overflow-x-auto rounded-default border border-base-200 dark:border-base-800 mb-4">
+        <table class="w-full">
+            <thead class="bg-base-100 dark:bg-base-800">
+                <tr>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark w-px">
+                        <input type="checkbox" id="action-toggle" class="rounded">
+                    </th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">ID</th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">
+                        {% if sort_direction == 'ascending' %}
+                            <a href="?desc=1" class="flex items-center gap-1">Created <span class="text-xs">↑</span></a>
+                        {% else %}
+                            <a href="?desc=0" class="flex items-center gap-1">Created <span class="text-xs">↓</span></a>
+                        {% endif %}
+                    </th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Status</th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Callable</th>
+                    {% block extra_columns %}{% endblock extra_columns %}
+                </tr>
+            </thead>
+            <tbody>
+                {% for job in jobs %}
+                <tr class="border-t border-base-200 dark:border-base-800 hover:bg-base-50 dark:hover:bg-base-800/50">
+                    <td class="p-3 px-4">
+                        <input class="action-select rounded" name="_selected_action" type="checkbox" value="{{ job.id }}">
+                    </td>
+                    <td class="p-3 px-4 text-sm">
+                        <a href="{% rq_url 'job_detail' queue_index job.id %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400 font-mono text-xs">{{ job.id }}</a>
+                    </td>
+                    <td class="p-3 px-4 text-sm whitespace-nowrap">
+                        {% if job.created_at %}{{ job.created_at|to_localtime|date:"Y-m-d, H:i:s" }}{% endif %}
+                    </td>
+                    <td class="p-3 px-4 text-sm">{{ job.get_status.value }}</td>
+                    <td class="p-3 px-4 text-sm font-mono text-xs">{{ job|show_func_name }}</td>
+                    {% block extra_columns_values %}{% endblock extra_columns_values %}
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <div class="flex gap-1 items-center text-sm">
+        {% for p in page_range %}
+            {% if p == page %}
+                <span class="font-medium px-3 py-1 rounded-default bg-primary-600 text-white">{{ p }}</span>
+            {% else %}
+                <a href="?page={{ p }}" class="border border-base-200 dark:border-base-800 hover:bg-base-50 dark:hover:bg-base-800 px-3 py-1 rounded-default">{{ p }}</a>
+            {% endif %}
+        {% endfor %}
+        <span class="ml-2 text-font-default-light dark:text-font-default-dark">{{ num_jobs }} jobs</span>
+    </div>
+</form>
+
+{% else %}
+
 <div id="content-main">
     <div class="module" id="changelist">
         <div class="changelist-form-container">
@@ -46,12 +114,6 @@
                         <select name="action" required>
                             <option value="" selected>---------</option>
                             <option value="delete">Delete</option>
-                            {% if job_status == 'Failed' %}
-                                <option value="requeue">Requeue</option>
-                            {% endif %}
-                            {% if job_status == 'Started' %}
-                                <option value="stop">Stop</option>
-                            {% endif %}
                         </select>
                     </label>
                     <button type="submit" class="button" title="Execute selected action" name="index" value="0">Go</button>
@@ -61,45 +123,23 @@
                         <thead>
                             <tr>
                                 <th scope="col" class="action-checkbox-column">
-                                    <div class="text">
-                                        <span><input type="checkbox" id="action-toggle"></span>
-                                    </div>
+                                    <div class="text"><span><input type="checkbox" id="action-toggle"></span></div>
                                     <div class="clear"></div>
                                 </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>ID</span></div>
-                                    <div class="clear"></div>
-                                </th>
+                                <th scope="col" class="sortable"><div class="text"><span>ID</span></div><div class="clear"></div></th>
                                 <th scope="col" class="sortable sorted {{ sort_direction }}">
                                     <div class="sortoptions">
-                                        {% if sort_direction == 'ascending' %}
-                                            <a href="?desc=1" class="toggle ascending" title="Toggle sorting"></a>
-                                        {% else %}
-                                            <a href="?desc=0" class="toggle descending" title="Toggle sorting"></a>
-                                        {% endif %}
-                                      </div>
-                                    <div class='text'>
-                                        {% if sort_direction == 'ascending' %}
-                                            <a href="?desc=1">
-                                        {% else %}
-                                            <a href="?desc=0">
-                                        {% endif %}
-                                        Created
-                                        </a>
+                                        {% if sort_direction == 'ascending' %}<a href="?desc=1" class="toggle ascending" title="Toggle sorting"></a>
+                                        {% else %}<a href="?desc=0" class="toggle descending" title="Toggle sorting"></a>{% endif %}
                                     </div>
-
+                                    <div class="text">
+                                        {% if sort_direction == 'ascending' %}<a href="?desc=1">Created</a>{% else %}<a href="?desc=0">Created</a>{% endif %}
+                                    </div>
                                     <div class="clear"></div>
                                 </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>Status</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>Callable</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                {% block extra_columns %}
-                                {% endblock extra_columns %}
+                                <th scope="col" class="sortable"><div class="text"><span>Status</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Callable</span></div><div class="clear"></div></th>
+                                {% block extra_columns %}{% endblock extra_columns %}
                             </tr>
                         </thead>
                         <tbody>
@@ -120,8 +160,7 @@
                                     </td>
                                     <td>{{ job.get_status.value }}</td>
                                     <td>{{ job|show_func_name }}</td>
-                                    {% block extra_columns_values %}
-                                    {% endblock extra_columns_values %}
+                                    {% block extra_columns_values %}{% endblock extra_columns_values %}
                                 </tr>
                             {% endfor %}
                         </tbody>
@@ -129,13 +168,9 @@
                 </div>
                 <p class="paginator">
                     {% for p in page_range %}
-                        {% if p == page %}
-                            <span class="this-page">{{ p }}</span>
-                        {% elif forloop.last %}
-                            <a href="?page={{ p }}" class="end">{{ p }}</a>
-                        {% else %}
-                            <a href="?page={{ p }}">{{ p }}</a>
-                        {% endif %}
+                        {% if p == page %}<span class="this-page">{{ p }}</span>
+                        {% elif forloop.last %}<a href="?page={{ p }}" class="end">{{ p }}</a>
+                        {% else %}<a href="?page={{ p }}">{{ p }}</a>{% endif %}
                     {% endfor %}
                     {{ num_jobs }} jobs
                 </p>
@@ -143,5 +178,7 @@
         </div>
     </div>
 </div>
+
+{% endif %}
 
 {% endblock %}

--- a/django_rq/templates/django_rq/delete_job.html
+++ b/django_rq/templates/django_rq/delete_job.html
@@ -4,22 +4,17 @@
 
 {% block extrastyle %}
     {{ block.super }}
-    <style>
-        .data {
-            display: inline-block;
-            float: left;
-            width: 80%;
-        }
-    </style>
+    {% if not unfold_installed %}
     <link href="{% static 'admin/css/forms.css' %}" type="text/css" rel="stylesheet">
+    {% endif %}
 {% endblock %}
 
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
         <a href="{% rq_url 'home' %}">Django RQ</a> &rsaquo;
-        <a href = "{% rq_url 'jobs' queue_index %}">{{ queue.name }}</a> &rsaquo;
-        <a href = "{% rq_url 'job_detail' queue_index job.id %}">{{ job.id }}</a> &rsaquo;
+        <a href="{% rq_url 'jobs' queue_index %}">{{ queue.name }}</a> &rsaquo;
+        <a href="{% rq_url 'job_detail' queue_index job.id %}">{{ job.id }}</a> &rsaquo;
         Delete
     </div>
 {% endblock %}
@@ -28,9 +23,24 @@
 
 {% block content %}
 
+{% if unfold_installed %}
+<h1 class="font-semibold mb-6 text-xl text-font-important-light dark:text-font-important-dark">Are you sure?</h1>
+<div class="border border-base-200 dark:border-base-800 rounded-default overflow-hidden mb-8">
+    <p class="p-4 text-sm">
+        Are you sure you want to delete
+        <a href="{% rq_url 'job_detail' queue_index job.id %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400">{{ job.id }}</a>
+        from <a href="{% rq_url 'jobs' queue_index %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400">{{ queue.name }}</a>?
+        This action can not be undone.
+    </p>
+    <form action="" method="post" class="border-t border-base-200 dark:border-base-800 px-4 py-3">
+        {% csrf_token %}
+        <button type="submit" class="bg-red-600 cursor-pointer font-medium hover:bg-red-500 px-3 py-2 rounded-default text-sm text-white">Yes, I'm sure</button>
+    </form>
+</div>
+{% else %}
 <div id="content-main">
     <p>
-        Are you sure you want to delete <a href = "{% rq_url 'job_detail' queue_index job.id %}">{{ job.id }}</a> from <a href = "{% rq_url 'jobs' queue_index %}">{{ queue.name }}</a>?
+        Are you sure you want to delete <a href="{% rq_url 'job_detail' queue_index job.id %}">{{ job.id }}</a> from <a href="{% rq_url 'jobs' queue_index %}">{{ queue.name }}</a>?
         This action can not be undone.
     </p>
     <form action="" method="post">
@@ -40,5 +50,6 @@
         </div>
     </form>
 </div>
+{% endif %}
 
 {% endblock %}

--- a/django_rq/templates/django_rq/failed_jobs.html
+++ b/django_rq/templates/django_rq/failed_jobs.html
@@ -75,7 +75,6 @@
                     </th>
                     <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Status</th>
                     <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Callable</th>
-                    {% block extra_columns %}{% endblock extra_columns %}
                 </tr>
             </thead>
             <tbody>
@@ -98,7 +97,6 @@
                     </td>
                     <td class="p-3 px-4 text-sm">{{ job.get_status.value }}</td>
                     <td class="p-3 px-4 text-sm font-mono text-xs">{{ job|show_func_name }}</td>
-                    {% block extra_columns_values %}{% endblock extra_columns_values %}
                 </tr>
                 {% endfor %}
             </tbody>

--- a/django_rq/templates/django_rq/failed_jobs.html
+++ b/django_rq/templates/django_rq/failed_jobs.html
@@ -6,7 +6,9 @@
 
 {% block extrastyle %}
     {{ block.super }}
+    {% if not unfold_installed %}
     <link rel="stylesheet" type="text/css" href="{% static "admin/css/changelists.css" %}">
+    {% endif %}
 {% endblock %}
 
 {% block extrahead %}
@@ -23,7 +25,6 @@
     </script>
 {% endblock %}
 
-
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
@@ -35,6 +36,87 @@
 {% block content_title %}<h1>{{ job_status }} jobs in {{ queue.name }}</h1>{% endblock %}
 
 {% block content %}
+
+{% if unfold_installed %}
+
+<h1 class="font-semibold mb-4 text-xl text-font-important-light dark:text-font-important-dark">{{ job_status }} jobs in {{ queue.name }}</h1>
+
+<div class="flex flex-wrap gap-2 mb-4">
+    <a href="{% rq_url 'requeue_all' queue_index %}" class="bg-primary-600 cursor-pointer font-medium hover:bg-primary-500 px-3 py-2 rounded-default text-sm text-white">Requeue All</a>
+    <a href="{% rq_url 'delete_failed_jobs' queue_index %}" class="bg-red-600 cursor-pointer font-medium hover:bg-red-500 px-3 py-2 rounded-default text-sm text-white">Delete All</a>
+</div>
+
+<form id="changelist-form" action="{% rq_url 'confirm_action' queue_index %}" method="post">
+    {% csrf_token %}
+    <div class="flex gap-2 items-center mb-4">
+        <select name="action" class="border border-base-200 dark:border-base-800 rounded-default bg-white dark:bg-base-900 px-3 py-2 text-sm" required>
+            <option value="" selected>---------</option>
+            <option value="delete">Delete</option>
+            <option value="requeue">Requeue</option>
+        </select>
+        <button type="submit" class="bg-primary-600 cursor-pointer font-medium hover:bg-primary-500 px-3 py-2 rounded-default text-sm text-white" name="index" value="0">Go</button>
+    </div>
+    <div class="overflow-x-auto rounded-default border border-base-200 dark:border-base-800 mb-4">
+        <table class="w-full">
+            <thead class="bg-base-100 dark:bg-base-800">
+                <tr>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark w-px">
+                        <input type="checkbox" id="action-toggle" class="rounded">
+                    </th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">ID</th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Created</th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Enqueued</th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">
+                        {% if sort_direction == 'ascending' %}
+                            <a href="?desc=1" class="flex items-center gap-1">Ended <span class="text-xs">↑</span></a>
+                        {% else %}
+                            <a href="?desc=0" class="flex items-center gap-1">Ended <span class="text-xs">↓</span></a>
+                        {% endif %}
+                    </th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Status</th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Callable</th>
+                    {% block extra_columns %}{% endblock extra_columns %}
+                </tr>
+            </thead>
+            <tbody>
+                {% for job in jobs %}
+                <tr class="border-t border-base-200 dark:border-base-800 hover:bg-base-50 dark:hover:bg-base-800/50">
+                    <td class="p-3 px-4">
+                        <input class="action-select rounded" name="_selected_action" type="checkbox" value="{{ job.id }}">
+                    </td>
+                    <td class="p-3 px-4 text-sm">
+                        <a href="{% rq_url 'job_detail' queue_index job.id %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400 font-mono text-xs">{{ job.id }}</a>
+                    </td>
+                    <td class="p-3 px-4 text-sm whitespace-nowrap">
+                        {% if job.created_at %}{{ job.created_at|to_localtime|date:"Y-m-d, H:i:s" }}{% endif %}
+                    </td>
+                    <td class="p-3 px-4 text-sm whitespace-nowrap">
+                        {% if job.enqueued_at %}{{ job.enqueued_at|to_localtime|date:"Y-m-d, H:i:s" }}{% endif %}
+                    </td>
+                    <td class="p-3 px-4 text-sm whitespace-nowrap">
+                        {% if job.ended_at %}{{ job.ended_at|to_localtime|date:"Y-m-d, H:i:s" }}{% endif %}
+                    </td>
+                    <td class="p-3 px-4 text-sm">{{ job.get_status.value }}</td>
+                    <td class="p-3 px-4 text-sm font-mono text-xs">{{ job|show_func_name }}</td>
+                    {% block extra_columns_values %}{% endblock extra_columns_values %}
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <div class="flex gap-1 items-center text-sm">
+        {% for p in page_range %}
+            {% if p == page %}
+                <span class="font-medium px-3 py-1 rounded-default bg-primary-600 text-white">{{ p }}</span>
+            {% else %}
+                <a href="?page={{ p }}" class="border border-base-200 dark:border-base-800 hover:bg-base-50 dark:hover:bg-base-800 px-3 py-1 rounded-default">{{ p }}</a>
+            {% endif %}
+        {% endfor %}
+        <span class="ml-2 text-font-default-light dark:text-font-default-dark">{{ num_jobs }} jobs</span>
+    </div>
+</form>
+
+{% else %}
 
 <div id="content-main">
     <ul class="object-tools">
@@ -60,23 +142,12 @@
                         <thead>
                             <tr>
                                 <th scope="col" class="action-checkbox-column">
-                                    <div class="text">
-                                        <span><input type="checkbox" id="action-toggle"></span>
-                                    </div>
+                                    <div class="text"><span><input type="checkbox" id="action-toggle"></span></div>
                                     <div class="clear"></div>
                                 </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>ID</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>Created</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>Enqueued</span></div>
-                                    <div class="clear"></div>
-                                </th>
+                                <th scope="col" class="sortable"><div class="text"><span>ID</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Created</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Enqueued</span></div><div class="clear"></div></th>
                                 <th scope="col" class="sortable sorted {{ sort_direction }}">
                                     <div class="sortoptions">
                                         {% if sort_direction == 'ascending' %}
@@ -84,28 +155,19 @@
                                         {% else %}
                                             <a href="?desc=0" class="toggle descending" title="Toggle sorting"></a>
                                         {% endif %}
-                                      </div>
-                                    <div class='text'>
+                                    </div>
+                                    <div class="text">
                                         {% if sort_direction == 'ascending' %}
-                                            <a href="?desc=1">
+                                            <a href="?desc=1">Ended</a>
                                         {% else %}
-                                            <a href="?desc=0">
+                                            <a href="?desc=0">Ended</a>
                                         {% endif %}
-                                            Ended
-                                        </a>
                                     </div>
                                     <div class="clear"></div>
                                 </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>Status</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>Callable</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                {% block extra_columns %}
-                                {% endblock extra_columns %}
+                                <th scope="col" class="sortable"><div class="text"><span>Status</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Callable</span></div><div class="clear"></div></th>
+                                {% block extra_columns %}{% endblock extra_columns %}
                             </tr>
                         </thead>
                         <tbody>
@@ -143,8 +205,7 @@
                                     </td>
                                     <td>{{ job.get_status.value }}</td>
                                     <td>{{ job|show_func_name }}</td>
-                                    {% block extra_columns_values %}
-                                    {% endblock extra_columns_values %}
+                                    {% block extra_columns_values %}{% endblock extra_columns_values %}
                                 </tr>
                             {% endfor %}
                         </tbody>
@@ -166,5 +227,7 @@
         </div>
     </div>
 </div>
+
+{% endif %}
 
 {% endblock %}

--- a/django_rq/templates/django_rq/finished_jobs.html
+++ b/django_rq/templates/django_rq/finished_jobs.html
@@ -75,7 +75,6 @@
                     </th>
                     <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Status</th>
                     <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Callable</th>
-                    {% block extra_columns %}{% endblock extra_columns %}
                 </tr>
             </thead>
             <tbody>
@@ -98,7 +97,6 @@
                     </td>
                     <td class="p-3 px-4 text-sm">{{ job.get_status.value }}</td>
                     <td class="p-3 px-4 text-sm font-mono text-xs">{{ job|show_func_name }}</td>
-                    {% block extra_columns_values %}{% endblock extra_columns_values %}
                 </tr>
                 {% endfor %}
             </tbody>

--- a/django_rq/templates/django_rq/finished_jobs.html
+++ b/django_rq/templates/django_rq/finished_jobs.html
@@ -6,7 +6,9 @@
 
 {% block extrastyle %}
     {{ block.super }}
+    {% if not unfold_installed %}
     <link rel="stylesheet" type="text/css" href="{% static "admin/css/changelists.css" %}">
+    {% endif %}
 {% endblock %}
 
 {% block extrahead %}
@@ -23,7 +25,6 @@
     </script>
 {% endblock %}
 
-
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
@@ -35,6 +36,87 @@
 {% block content_title %}<h1>{{ job_status }} jobs in {{ queue.name }}</h1>{% endblock %}
 
 {% block content %}
+
+{% if unfold_installed %}
+
+<h1 class="font-semibold mb-4 text-xl text-font-important-light dark:text-font-important-dark">{{ job_status }} jobs in {{ queue.name }}</h1>
+
+<div class="flex flex-wrap gap-2 mb-4">
+    <a href="{% rq_url 'requeue_all' queue_index %}" class="bg-primary-600 cursor-pointer font-medium hover:bg-primary-500 px-3 py-2 rounded-default text-sm text-white">Requeue All</a>
+    <a href="{% rq_url 'delete_failed_jobs' queue_index %}" class="bg-red-600 cursor-pointer font-medium hover:bg-red-500 px-3 py-2 rounded-default text-sm text-white">Delete All</a>
+</div>
+
+<form id="changelist-form" action="{% rq_url 'confirm_action' queue_index %}" method="post">
+    {% csrf_token %}
+    <div class="flex gap-2 items-center mb-4">
+        <select name="action" class="border border-base-200 dark:border-base-800 rounded-default bg-white dark:bg-base-900 px-3 py-2 text-sm" required>
+            <option value="" selected>---------</option>
+            <option value="delete">Delete</option>
+            <option value="requeue">Requeue</option>
+        </select>
+        <button type="submit" class="bg-primary-600 cursor-pointer font-medium hover:bg-primary-500 px-3 py-2 rounded-default text-sm text-white" name="index" value="0">Go</button>
+    </div>
+    <div class="overflow-x-auto rounded-default border border-base-200 dark:border-base-800 mb-4">
+        <table class="w-full">
+            <thead class="bg-base-100 dark:bg-base-800">
+                <tr>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark w-px">
+                        <input type="checkbox" id="action-toggle" class="rounded">
+                    </th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">ID</th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Created</th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Enqueued</th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">
+                        {% if sort_direction == 'ascending' %}
+                            <a href="?desc=1" class="flex items-center gap-1">Ended <span class="text-xs">↑</span></a>
+                        {% else %}
+                            <a href="?desc=0" class="flex items-center gap-1">Ended <span class="text-xs">↓</span></a>
+                        {% endif %}
+                    </th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Status</th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Callable</th>
+                    {% block extra_columns %}{% endblock extra_columns %}
+                </tr>
+            </thead>
+            <tbody>
+                {% for job in jobs %}
+                <tr class="border-t border-base-200 dark:border-base-800 hover:bg-base-50 dark:hover:bg-base-800/50">
+                    <td class="p-3 px-4">
+                        <input class="action-select rounded" name="_selected_action" type="checkbox" value="{{ job.id }}">
+                    </td>
+                    <td class="p-3 px-4 text-sm">
+                        <a href="{% rq_url 'job_detail' queue_index job.id %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400 font-mono text-xs">{{ job.id }}</a>
+                    </td>
+                    <td class="p-3 px-4 text-sm whitespace-nowrap">
+                        {% if job.created_at %}{{ job.created_at|to_localtime|date:"Y-m-d, H:i:s" }}{% endif %}
+                    </td>
+                    <td class="p-3 px-4 text-sm whitespace-nowrap">
+                        {% if job.enqueued_at %}{{ job.enqueued_at|to_localtime|date:"Y-m-d, H:i:s" }}{% endif %}
+                    </td>
+                    <td class="p-3 px-4 text-sm whitespace-nowrap">
+                        {% if job.ended_at %}{{ job.ended_at|to_localtime|date:"Y-m-d, H:i:s" }}{% endif %}
+                    </td>
+                    <td class="p-3 px-4 text-sm">{{ job.get_status.value }}</td>
+                    <td class="p-3 px-4 text-sm font-mono text-xs">{{ job|show_func_name }}</td>
+                    {% block extra_columns_values %}{% endblock extra_columns_values %}
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <div class="flex gap-1 items-center text-sm">
+        {% for p in page_range %}
+            {% if p == page %}
+                <span class="font-medium px-3 py-1 rounded-default bg-primary-600 text-white">{{ p }}</span>
+            {% else %}
+                <a href="?page={{ p }}" class="border border-base-200 dark:border-base-800 hover:bg-base-50 dark:hover:bg-base-800 px-3 py-1 rounded-default">{{ p }}</a>
+            {% endif %}
+        {% endfor %}
+        <span class="ml-2 text-font-default-light dark:text-font-default-dark">{{ num_jobs }} jobs</span>
+    </div>
+</form>
+
+{% else %}
 
 <div id="content-main">
     <ul class="object-tools">
@@ -60,52 +142,25 @@
                         <thead>
                             <tr>
                                 <th scope="col" class="action-checkbox-column">
-                                    <div class="text">
-                                        <span><input type="checkbox" id="action-toggle"></span>
-                                    </div>
+                                    <div class="text"><span><input type="checkbox" id="action-toggle"></span></div>
                                     <div class="clear"></div>
                                 </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>ID</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>Created</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>Enqueued</span></div>
-                                    <div class="clear"></div>
-                                </th>
+                                <th scope="col" class="sortable"><div class="text"><span>ID</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Created</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Enqueued</span></div><div class="clear"></div></th>
                                 <th scope="col" class="sortable sorted {{ sort_direction }}">
                                     <div class="sortoptions">
-                                        {% if sort_direction == 'ascending' %}
-                                            <a href="?desc=1" class="toggle ascending" title="Toggle sorting"></a>
-                                        {% else %}
-                                            <a href="?desc=0" class="toggle descending" title="Toggle sorting"></a>
-                                        {% endif %}
-                                      </div>
-                                    <div class='text'>
-                                        {% if sort_direction == 'ascending' %}
-                                            <a href="?desc=1">
-                                        {% else %}
-                                            <a href="?desc=0">
-                                        {% endif %}
-                                            Ended
-                                        </a>
+                                        {% if sort_direction == 'ascending' %}<a href="?desc=1" class="toggle ascending" title="Toggle sorting"></a>
+                                        {% else %}<a href="?desc=0" class="toggle descending" title="Toggle sorting"></a>{% endif %}
+                                    </div>
+                                    <div class="text">
+                                        {% if sort_direction == 'ascending' %}<a href="?desc=1">Ended</a>{% else %}<a href="?desc=0">Ended</a>{% endif %}
                                     </div>
                                     <div class="clear"></div>
                                 </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>Status</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>Callable</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                {% block extra_columns %}
-                                {% endblock extra_columns %}
+                                <th scope="col" class="sortable"><div class="text"><span>Status</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Callable</span></div><div class="clear"></div></th>
+                                {% block extra_columns %}{% endblock extra_columns %}
                             </tr>
                         </thead>
                         <tbody>
@@ -143,8 +198,7 @@
                                     </td>
                                     <td>{{ job.get_status.value }}</td>
                                     <td>{{ job|show_func_name }}</td>
-                                    {% block extra_columns_values %}
-                                    {% endblock extra_columns_values %}
+                                    {% block extra_columns_values %}{% endblock extra_columns_values %}
                                 </tr>
                             {% endfor %}
                         </tbody>
@@ -152,13 +206,9 @@
                 </div>
                 <p class="paginator">
                     {% for p in page_range %}
-                        {% if p == page %}
-                            <span class="this-page">{{ p }}</span>
-                        {% elif forloop.last %}
-                            <a href="?page={{ p }}" class="end">{{ p }}</a>
-                        {% else %}
-                            <a href="?page={{ p }}">{{ p }}</a>
-                        {% endif %}
+                        {% if p == page %}<span class="this-page">{{ p }}</span>
+                        {% elif forloop.last %}<a href="?page={{ p }}" class="end">{{ p }}</a>
+                        {% else %}<a href="?page={{ p }}">{{ p }}</a>{% endif %}
                     {% endfor %}
                     {{ num_jobs }} jobs
                 </p>
@@ -166,5 +216,7 @@
         </div>
     </div>
 </div>
+
+{% endif %}
 
 {% endblock %}

--- a/django_rq/templates/django_rq/job_detail.html
+++ b/django_rq/templates/django_rq/job_detail.html
@@ -6,8 +6,10 @@
 
 {% block extrastyle %}
     {{ block.super }}
+    {% if not unfold_installed %}
     <link rel="stylesheet" type="text/css" href="{% static 'admin/css/forms.css' %}">
     <link rel="stylesheet" type="text/css" href="{% static 'django_rq/css/admin.css' %}">
+    {% endif %}
 {% endblock %}
 
 {% block breadcrumbs %}
@@ -24,6 +26,181 @@
 {% block object-tools %}{% endblock %}
 
 {% block content %}
+
+{% if unfold_installed %}
+
+<h1 class="font-semibold mb-4 text-xl text-font-important-light dark:text-font-important-dark">Job {{ job.id }}</h1>
+
+<div class="border border-base-200 dark:border-base-800 rounded-default mb-6 overflow-hidden">
+    <div class="flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-36 text-font-default-light dark:text-font-default-dark text-sm">Queue</span>
+        <span class="text-sm">{{ job.origin }}</span>
+    </div>
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-36 text-font-default-light dark:text-font-default-dark text-sm">Timeout</span>
+        <span class="text-sm">{{ job.timeout }}</span>
+    </div>
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-36 text-font-default-light dark:text-font-default-dark text-sm">Result TTL</span>
+        <span class="text-sm">{{ job.result_ttl }}</span>
+    </div>
+    {% if job.created_at %}
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-36 text-font-default-light dark:text-font-default-dark text-sm">Created</span>
+        <span class="text-sm">{{ job.created_at|to_localtime|date:"Y-m-d, H:i:s" }}</span>
+    </div>
+    {% endif %}
+    {% if job.enqueued_at %}
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-36 text-font-default-light dark:text-font-default-dark text-sm">Queued</span>
+        <span class="text-sm">{{ job.enqueued_at|to_localtime|date:"Y-m-d, H:i:s" }}</span>
+    </div>
+    {% endif %}
+    {% if job.started_at %}
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-36 text-font-default-light dark:text-font-default-dark text-sm">Started</span>
+        <span class="text-sm">{{ job.started_at|to_localtime|date:"Y-m-d, H:i:s" }}</span>
+    </div>
+    {% endif %}
+    {% if job.ended_at %}
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-36 text-font-default-light dark:text-font-default-dark text-sm">Ended</span>
+        <span class="text-sm">{{ job.ended_at|to_localtime|date:"Y-m-d, H:i:s" }}</span>
+    </div>
+    {% endif %}
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-36 text-font-default-light dark:text-font-default-dark text-sm">Status</span>
+        <span class="text-sm">{{ job.get_status.value }}</span>
+    </div>
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-36 text-font-default-light dark:text-font-default-dark text-sm">Callable</span>
+        <span class="text-sm font-mono">{{ job|show_func_name }}</span>
+    </div>
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-36 text-font-default-light dark:text-font-default-dark text-sm">Meta</span>
+        <span class="text-sm font-mono">{{ job.meta }}</span>
+    </div>
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-36 text-font-default-light dark:text-font-default-dark text-sm">Args</span>
+        <div class="text-sm">
+            {% if data_is_valid %}
+                {% if job.args %}
+                <ul class="list-disc pl-4 space-y-1">
+                    {% for arg in job.args %}
+                    <li class="font-mono text-xs">{{ arg|force_escape }}</li>
+                    {% endfor %}
+                </ul>
+                {% endif %}
+            {% else %}
+                <span class="text-red-600 dark:text-red-400">Unpickling Error</span>
+            {% endif %}
+        </div>
+    </div>
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-36 text-font-default-light dark:text-font-default-dark text-sm">Kwargs</span>
+        <div class="text-sm">
+            {% if data_is_valid %}
+                {% if job.kwargs %}
+                <ul class="list-disc pl-4 space-y-1">
+                    {% for key, value in job.kwargs|items %}
+                    <li class="font-mono text-xs">{{ key }}: {{ value|force_escape }}</li>
+                    {% endfor %}
+                </ul>
+                {% endif %}
+            {% else %}
+                <span class="text-red-600 dark:text-red-400">Unpickling Error</span>
+            {% endif %}
+        </div>
+    </div>
+    {% if dependencies %}
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-36 text-font-default-light dark:text-font-default-dark text-sm">Depends On</span>
+        <div class="text-sm space-y-1">
+            {% for dependency in dependencies %}
+            <div>
+                {% if dependency.1 %}{{ dependency.1.func_name }}{% else %}Deleted{% endif %}
+                <a href="{% rq_url 'job_detail' queue_index dependency.0 %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400 font-mono text-xs ml-1">({{ dependency.0 }})</a>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+    {% if dependents %}
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-36 text-font-default-light dark:text-font-default-dark text-sm">Dependents</span>
+        <div class="text-sm space-y-1">
+            {% for dependent in dependents %}
+            <div>
+                {% if dependent.1 %}{{ dependent.1.func_name }}{% else %}Deleted{% endif %}
+                <a href="{% rq_url 'job_detail' queue_index dependent.0 %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400 font-mono text-xs ml-1">({{ dependent.0 }})</a>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+    {% endif %}
+    {% if exc_info %}
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 p-3 px-4">
+        <span class="font-semibold min-w-36 text-font-default-light dark:text-font-default-dark text-sm">Exception</span>
+        <pre class="text-xs font-mono bg-base-100 dark:bg-base-800 p-3 rounded-default overflow-x-auto flex-1">{% if job.exc_info %}{{ job.exc_info|linebreaks }}{% endif %}</pre>
+    </div>
+    {% endif %}
+    {% if job.legacy_result %}
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-36 text-font-default-light dark:text-font-default-dark text-sm">Result</span>
+        <span class="text-sm font-mono">{{ job.result }}</span>
+    </div>
+    {% endif %}
+</div>
+
+<div class="flex flex-wrap gap-2 mb-8">
+    <a href="delete/" class="bg-red-600 cursor-pointer font-medium hover:bg-red-500 px-3 py-2 rounded-default text-sm text-white">Delete</a>
+    {% if job.is_started %}
+    <form method="post" action="{% rq_url 'stop_job' queue_index job.id %}">
+        {% csrf_token %}
+        <button type="submit" class="bg-red-600 cursor-pointer font-medium hover:bg-red-500 px-3 py-2 rounded-default text-sm text-white" name="stop">Stop</button>
+    </form>
+    {% endif %}
+    {% if job.is_failed %}
+    <form method="post" action="{% rq_url 'requeue_job' queue_index job.id %}">
+        {% csrf_token %}
+        <button type="submit" class="bg-primary-600 cursor-pointer font-medium hover:bg-primary-500 px-3 py-2 rounded-default text-sm text-white" name="requeue">Requeue</button>
+    </form>
+    {% endif %}
+    {% if not job.is_queued and not job.is_failed %}
+    <form method="post" action="{% rq_url 'enqueue_job' queue_index job.id %}">
+        {% csrf_token %}
+        <button type="submit" class="bg-primary-600 cursor-pointer font-medium hover:bg-primary-500 px-3 py-2 rounded-default text-sm text-white" name="Enqueue">Enqueue</button>
+    </form>
+    {% endif %}
+</div>
+
+{% for result in job.results %}
+<h2 class="font-semibold mb-3 text-base text-font-important-light dark:text-font-important-dark">Result {{ result.id }}</h2>
+<div class="border border-base-200 dark:border-base-800 rounded-default mb-6 overflow-hidden">
+    <div class="flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-36 text-font-default-light dark:text-font-default-dark text-sm">Type</span>
+        <span class="text-sm">{{ result.type.name }}</span>
+    </div>
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-36 text-font-default-light dark:text-font-default-dark text-sm">Created at</span>
+        <span class="text-sm">{{ result.created_at|to_localtime|date:"Y-m-d, H:i:s" }}</span>
+    </div>
+    {% if result.type.value == 1 %}
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 p-3 px-4">
+        <span class="font-semibold min-w-36 text-font-default-light dark:text-font-default-dark text-sm">Return value</span>
+        <pre class="text-xs font-mono bg-base-100 dark:bg-base-800 p-3 rounded-default overflow-x-auto flex-1">{{ result.return_value }}</pre>
+    </div>
+    {% elif result.type.value == 2 %}
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 p-3 px-4">
+        <span class="font-semibold min-w-36 text-font-default-light dark:text-font-default-dark text-sm">Exception</span>
+        <pre class="text-xs font-mono bg-base-100 dark:bg-base-800 p-3 rounded-default overflow-x-auto flex-1">{{ result.exc_string }}</pre>
+    </div>
+    {% endif %}
+</div>
+{% endfor %}
+
+{% else %}
+
 {% with status=job.get_status.value %}
 <div id="content-main">
 
@@ -244,5 +421,7 @@
 
 </div>
 {% endwith %}
+
+{% endif %}
 
 {% endblock %}

--- a/django_rq/templates/django_rq/jobs.html
+++ b/django_rq/templates/django_rq/jobs.html
@@ -83,7 +83,6 @@
                     <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Ended</th>
                     <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Status</th>
                     <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Callable</th>
-                    {% block extra_columns %}{% endblock extra_columns %}
                 </tr>
             </thead>
             <tbody>
@@ -111,7 +110,6 @@
                     </td>
                     <td class="p-3 px-4 text-sm">{{ job.get_status.value }}</td>
                     <td class="p-3 px-4 text-sm font-mono text-xs">{{ job|show_func_name }}</td>
-                    {% block extra_columns_values %}{% endblock extra_columns_values %}
                 </tr>
                 {% endfor %}
             </tbody>

--- a/django_rq/templates/django_rq/jobs.html
+++ b/django_rq/templates/django_rq/jobs.html
@@ -6,7 +6,9 @@
 
 {% block extrastyle %}
     {{ block.super }}
+    {% if not unfold_installed %}
     <link rel="stylesheet" type="text/css" href="{% static "admin/css/changelists.css" %}">
+    {% endif %}
 {% endblock %}
 
 {% block extrahead %}
@@ -23,7 +25,6 @@
     </script>
 {% endblock %}
 
-
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
@@ -35,6 +36,100 @@
 {% block content_title %}<h1>{{ job_status }} jobs in {{ queue.name }}</h1>{% endblock %}
 
 {% block content %}
+
+{% if unfold_installed %}
+
+<h1 class="font-semibold mb-4 text-xl text-font-important-light dark:text-font-important-dark">{{ job_status }} jobs in {{ queue.name }}</h1>
+
+{% if job_status == 'Failed' or job_status == 'Queued' %}
+<div class="flex flex-wrap gap-2 mb-4">
+    {% if job_status == 'Failed' %}
+    <a href="{% rq_url 'requeue_all' queue_index %}" class="bg-primary-600 cursor-pointer font-medium hover:bg-primary-500 px-3 py-2 rounded-default text-sm text-white">Requeue All</a>
+    <a href="{% rq_url 'delete_failed_jobs' queue_index %}" class="bg-red-600 cursor-pointer font-medium hover:bg-red-500 px-3 py-2 rounded-default text-sm text-white">Delete All</a>
+    {% elif job_status == 'Queued' %}
+    <a href="{% rq_url 'clear' queue_index %}" class="bg-red-600 cursor-pointer font-medium hover:bg-red-500 px-3 py-2 rounded-default text-sm text-white">Empty Queue</a>
+    {% endif %}
+</div>
+{% endif %}
+
+<form id="changelist-form" action="{% rq_url 'confirm_action' queue_index %}" method="post">
+    {% csrf_token %}
+    <div class="flex gap-2 items-center mb-4">
+        <select name="action" class="border border-base-200 dark:border-base-800 rounded-default bg-white dark:bg-base-900 px-3 py-2 text-sm" required>
+            <option value="" selected>---------</option>
+            <option value="delete">Delete</option>
+            {% if job_status == 'Failed' %}
+                <option value="requeue">Requeue</option>
+            {% endif %}
+            {% if job_status == 'Started' %}
+                <option value="stop">Stop</option>
+            {% endif %}
+        </select>
+        <button type="submit" class="bg-primary-600 cursor-pointer font-medium hover:bg-primary-500 px-3 py-2 rounded-default text-sm text-white" name="index" value="0">Go</button>
+    </div>
+    <div class="overflow-x-auto rounded-default border border-base-200 dark:border-base-800 mb-4">
+        <table class="w-full">
+            <thead class="bg-base-100 dark:bg-base-800">
+                <tr>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark w-px">
+                        <input type="checkbox" id="action-toggle" class="rounded">
+                    </th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">ID</th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Created</th>
+                    {% if job_status == 'Scheduled' %}
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Scheduled</th>
+                    {% endif %}
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Enqueued</th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Ended</th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Status</th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Callable</th>
+                    {% block extra_columns %}{% endblock extra_columns %}
+                </tr>
+            </thead>
+            <tbody>
+                {% for job in jobs %}
+                <tr class="border-t border-base-200 dark:border-base-800 hover:bg-base-50 dark:hover:bg-base-800/50">
+                    <td class="p-3 px-4">
+                        <input class="action-select rounded" name="_selected_action" type="checkbox" value="{{ job.id }}">
+                    </td>
+                    <td class="p-3 px-4 text-sm">
+                        <a href="{% rq_url 'job_detail' queue_index job.id %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400 font-mono text-xs">{{ job.id }}</a>
+                    </td>
+                    <td class="p-3 px-4 text-sm whitespace-nowrap">
+                        {% if job.created_at %}{{ job.created_at|to_localtime|date:"Y-m-d, H:i:s" }}{% endif %}
+                    </td>
+                    {% if job_status == 'Scheduled' %}
+                    <td class="p-3 px-4 text-sm whitespace-nowrap">
+                        {% if job.scheduled_at %}{{ job.scheduled_at|to_localtime|date:"Y-m-d, H:i:s" }}{% endif %}
+                    </td>
+                    {% endif %}
+                    <td class="p-3 px-4 text-sm whitespace-nowrap">
+                        {% if job.enqueued_at %}{{ job.enqueued_at|to_localtime|date:"Y-m-d, H:i:s" }}{% endif %}
+                    </td>
+                    <td class="p-3 px-4 text-sm whitespace-nowrap">
+                        {% if job.ended_at %}{{ job.ended_at|to_localtime|date:"Y-m-d, H:i:s" }}{% endif %}
+                    </td>
+                    <td class="p-3 px-4 text-sm">{{ job.get_status.value }}</td>
+                    <td class="p-3 px-4 text-sm font-mono text-xs">{{ job|show_func_name }}</td>
+                    {% block extra_columns_values %}{% endblock extra_columns_values %}
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <div class="flex gap-1 items-center text-sm">
+        {% for p in page_range %}
+            {% if p == page %}
+                <span class="font-medium px-3 py-1 rounded-default bg-primary-600 text-white">{{ p }}</span>
+            {% else %}
+                <a href="?page={{ p }}" class="border border-base-200 dark:border-base-800 hover:bg-base-50 dark:hover:bg-base-800 px-3 py-1 rounded-default">{{ p }}</a>
+            {% endif %}
+        {% endfor %}
+        <span class="ml-2 text-font-default-light dark:text-font-default-dark">{{ num_jobs }} jobs</span>
+    </div>
+</form>
+
+{% else %}
 
 <div id="content-main">
     <ul class="object-tools">
@@ -69,43 +164,19 @@
                         <thead>
                             <tr>
                                 <th scope="col" class="action-checkbox-column">
-                                    <div class="text">
-                                        <span><input type="checkbox" id="action-toggle"></span>
-                                    </div>
+                                    <div class="text"><span><input type="checkbox" id="action-toggle"></span></div>
                                     <div class="clear"></div>
                                 </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>ID</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>Created</span></div>
-                                    <div class="clear"></div>
-                                </th>
+                                <th scope="col" class="sortable"><div class="text"><span>ID</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Created</span></div><div class="clear"></div></th>
                                 {% if job_status == 'Scheduled' %}
-                                    <th scope="col" class="sortable">
-                                        <div class='text'><span>Scheduled</span></div>
-                                        <div class="clear"></div>
-                                    </th>
+                                <th scope="col" class="sortable"><div class="text"><span>Scheduled</span></div><div class="clear"></div></th>
                                 {% endif %}
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>Enqueued</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>Ended</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>Status</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>Callable</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                {% block extra_columns %}
-                                {% endblock extra_columns %}
+                                <th scope="col" class="sortable"><div class="text"><span>Enqueued</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Ended</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Status</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Callable</span></div><div class="clear"></div></th>
+                                {% block extra_columns %}{% endblock extra_columns %}
                             </tr>
                         </thead>
                         <tbody>
@@ -143,8 +214,7 @@
                                     </td>
                                     <td>{{ job.get_status.value }}</td>
                                     <td>{{ job|show_func_name }}</td>
-                                    {% block extra_columns_values %}
-                                    {% endblock extra_columns_values %}
+                                    {% block extra_columns_values %}{% endblock extra_columns_values %}
                                 </tr>
                             {% endfor %}
                         </tbody>
@@ -166,5 +236,7 @@
         </div>
     </div>
 </div>
+
+{% endif %}
 
 {% endblock %}

--- a/django_rq/templates/django_rq/requeue_all.html
+++ b/django_rq/templates/django_rq/requeue_all.html
@@ -4,21 +4,16 @@
 
 {% block extrastyle %}
     {{ block.super }}
-    <style>
-        .data {
-            display: inline-block;
-            float: left;
-            width: 80%;
-        }
-    </style>
+    {% if not unfold_installed %}
     <link href="{% static 'admin/css/forms.css' %}" type="text/css" rel="stylesheet">
+    {% endif %}
 {% endblock %}
 
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
         <a href="{% rq_url 'home' %}">Django RQ</a> &rsaquo;
-        <a href = "{% rq_url 'jobs' queue_index %}">{{ queue.name }}</a> &rsaquo;
+        <a href="{% rq_url 'jobs' queue_index %}">{{ queue.name }}</a> &rsaquo;
         Requeue All
     </div>
 {% endblock %}
@@ -27,9 +22,22 @@
 
 {% block content %}
 
+{% if unfold_installed %}
+<h1 class="font-semibold mb-6 text-xl text-font-important-light dark:text-font-important-dark">Are you sure?</h1>
+<div class="border border-base-200 dark:border-base-800 rounded-default overflow-hidden mb-8">
+    <p class="p-4 text-sm">
+        Are you sure you want to requeue {{ total_jobs }} job{{ total_jobs|pluralize }} in the <a href="{% rq_url 'jobs' queue_index %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400">{{ queue.name }}</a> queue?
+        This action can not be undone.
+    </p>
+    <form action="" method="post" class="border-t border-base-200 dark:border-base-800 px-4 py-3">
+        {% csrf_token %}
+        <button type="submit" class="bg-primary-600 cursor-pointer font-medium hover:bg-primary-500 px-3 py-2 rounded-default text-sm text-white">Yes, I'm sure</button>
+    </form>
+</div>
+{% else %}
 <div id="content-main">
     <p>
-        Are you sure you want to requeue {{ total_jobs }} job{{ total_jobs|pluralize }} in the <a href = "{% rq_url 'jobs' queue_index %}">{{ queue.name }}</a> queue?
+        Are you sure you want to requeue {{ total_jobs }} job{{ total_jobs|pluralize }} in the <a href="{% rq_url 'jobs' queue_index %}">{{ queue.name }}</a> queue?
         This action can not be undone.
     </p>
     <form action="" method="post">
@@ -39,5 +47,6 @@
         </div>
     </form>
 </div>
+{% endif %}
 
 {% endblock %}

--- a/django_rq/templates/django_rq/scheduled_jobs.html
+++ b/django_rq/templates/django_rq/scheduled_jobs.html
@@ -68,7 +68,6 @@
                     </th>
                     <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Status</th>
                     <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Callable</th>
-                    {% block extra_columns %}{% endblock extra_columns %}
                 </tr>
             </thead>
             <tbody>
@@ -88,7 +87,6 @@
                     </td>
                     <td class="p-3 px-4 text-sm">{{ job.get_status.value }}</td>
                     <td class="p-3 px-4 text-sm font-mono text-xs">{{ job|show_func_name }}</td>
-                    {% block extra_columns_values %}{% endblock extra_columns_values %}
                 </tr>
                 {% endfor %}
             </tbody>

--- a/django_rq/templates/django_rq/scheduled_jobs.html
+++ b/django_rq/templates/django_rq/scheduled_jobs.html
@@ -6,7 +6,9 @@
 
 {% block extrastyle %}
     {{ block.super }}
+    {% if not unfold_installed %}
     <link rel="stylesheet" type="text/css" href="{% static "admin/css/changelists.css" %}">
+    {% endif %}
 {% endblock %}
 
 {% block extrahead %}
@@ -23,7 +25,6 @@
     </script>
 {% endblock %}
 
-
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
@@ -36,6 +37,77 @@
 
 {% block content %}
 
+{% if unfold_installed %}
+
+<h1 class="font-semibold mb-4 text-xl text-font-important-light dark:text-font-important-dark">Scheduled jobs in {{ queue.name }}</h1>
+
+<form id="changelist-form" action="{% rq_url 'confirm_action' queue_index %}" method="post">
+    {% csrf_token %}
+    <div class="flex gap-2 items-center mb-4">
+        <select name="action" class="border border-base-200 dark:border-base-800 rounded-default bg-white dark:bg-base-900 px-3 py-2 text-sm" required>
+            <option value="" selected>---------</option>
+            <option value="delete">Delete</option>
+        </select>
+        <button type="submit" class="bg-primary-600 cursor-pointer font-medium hover:bg-primary-500 px-3 py-2 rounded-default text-sm text-white" name="index" value="0">Go</button>
+    </div>
+    <div class="overflow-x-auto rounded-default border border-base-200 dark:border-base-800 mb-4">
+        <table class="w-full">
+            <thead class="bg-base-100 dark:bg-base-800">
+                <tr>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark w-px">
+                        <input type="checkbox" id="action-toggle" class="rounded">
+                    </th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">ID</th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Created</th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">
+                        {% if sort_direction == 'ascending' %}
+                            <a href="?desc=1" class="flex items-center gap-1">Scheduled <span class="text-xs">↑</span></a>
+                        {% else %}
+                            <a href="?desc=0" class="flex items-center gap-1">Scheduled <span class="text-xs">↓</span></a>
+                        {% endif %}
+                    </th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Status</th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Callable</th>
+                    {% block extra_columns %}{% endblock extra_columns %}
+                </tr>
+            </thead>
+            <tbody>
+                {% for job in jobs %}
+                <tr class="border-t border-base-200 dark:border-base-800 hover:bg-base-50 dark:hover:bg-base-800/50">
+                    <td class="p-3 px-4">
+                        <input class="action-select rounded" name="_selected_action" type="checkbox" value="{{ job.id }}">
+                    </td>
+                    <td class="p-3 px-4 text-sm">
+                        <a href="{% rq_url 'job_detail' queue_index job.id %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400 font-mono text-xs">{{ job.id }}</a>
+                    </td>
+                    <td class="p-3 px-4 text-sm whitespace-nowrap">
+                        {% if job.created_at %}{{ job.created_at|to_localtime|date:"Y-m-d, H:i:s" }}{% endif %}
+                    </td>
+                    <td class="p-3 px-4 text-sm whitespace-nowrap">
+                        {% if job.scheduled_at %}{{ job.scheduled_at|to_localtime|date:"Y-m-d, H:i:s" }}{% endif %}
+                    </td>
+                    <td class="p-3 px-4 text-sm">{{ job.get_status.value }}</td>
+                    <td class="p-3 px-4 text-sm font-mono text-xs">{{ job|show_func_name }}</td>
+                    {% block extra_columns_values %}{% endblock extra_columns_values %}
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <div class="flex gap-1 items-center text-sm">
+        {% for p in page_range %}
+            {% if p == page %}
+                <span class="font-medium px-3 py-1 rounded-default bg-primary-600 text-white">{{ p }}</span>
+            {% else %}
+                <a href="?page={{ p }}" class="border border-base-200 dark:border-base-800 hover:bg-base-50 dark:hover:bg-base-800 px-3 py-1 rounded-default">{{ p }}</a>
+            {% endif %}
+        {% endfor %}
+        <span class="ml-2 text-font-default-light dark:text-font-default-dark">{{ num_jobs }} jobs</span>
+    </div>
+</form>
+
+{% else %}
+
 <div id="content-main">
     <div class="module" id="changelist">
         <div class="changelist-form-container">
@@ -46,12 +118,6 @@
                         <select name="action" required>
                             <option value="" selected>---------</option>
                             <option value="delete">Delete</option>
-                            {% if job_status == 'Failed' %}
-                                <option value="requeue">Requeue</option>
-                            {% endif %}
-                            {% if job_status == 'Started' %}
-                                <option value="stop">Stop</option>
-                            {% endif %}
                         </select>
                     </label>
                     <button type="submit" class="button" title="Execute selected action" name="index" value="0">Go</button>
@@ -61,48 +127,24 @@
                         <thead>
                             <tr>
                                 <th scope="col" class="action-checkbox-column">
-                                    <div class="text">
-                                        <span><input type="checkbox" id="action-toggle"></span>
-                                    </div>
+                                    <div class="text"><span><input type="checkbox" id="action-toggle"></span></div>
                                     <div class="clear"></div>
                                 </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>ID</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>Created</span></div>
-                                    <div class="clear"></div>
-                                </th>
+                                <th scope="col" class="sortable"><div class="text"><span>ID</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Created</span></div><div class="clear"></div></th>
                                 <th scope="col" class="sortable sorted {{ sort_direction }}">
                                     <div class="sortoptions">
-                                        {% if sort_direction == 'ascending' %}
-                                            <a href="?desc=1" class="toggle ascending" title="Toggle sorting"></a>
-                                        {% else %}
-                                            <a href="?desc=0" class="toggle descending" title="Toggle sorting"></a>
-                                        {% endif %}
-                                      </div>
-                                    <div class='text'>
-                                        {% if sort_direction == 'ascending' %}
-                                            <a href="?desc=1">
-                                        {% else %}
-                                            <a href="?desc=0">
-                                        {% endif %}
-                                        Scheduled
-                                        </a>
+                                        {% if sort_direction == 'ascending' %}<a href="?desc=1" class="toggle ascending" title="Toggle sorting"></a>
+                                        {% else %}<a href="?desc=0" class="toggle descending" title="Toggle sorting"></a>{% endif %}
+                                    </div>
+                                    <div class="text">
+                                        {% if sort_direction == 'ascending' %}<a href="?desc=1">Scheduled</a>{% else %}<a href="?desc=0">Scheduled</a>{% endif %}
                                     </div>
                                     <div class="clear"></div>
                                 </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>Status</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>Callable</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                {% block extra_columns %}
-                                {% endblock extra_columns %}
+                                <th scope="col" class="sortable"><div class="text"><span>Status</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Callable</span></div><div class="clear"></div></th>
+                                {% block extra_columns %}{% endblock extra_columns %}
                             </tr>
                         </thead>
                         <tbody>
@@ -128,8 +170,7 @@
                                     </td>
                                     <td>{{ job.get_status.value }}</td>
                                     <td>{{ job|show_func_name }}</td>
-                                    {% block extra_columns_values %}
-                                    {% endblock extra_columns_values %}
+                                    {% block extra_columns_values %}{% endblock extra_columns_values %}
                                 </tr>
                             {% endfor %}
                         </tbody>
@@ -137,13 +178,9 @@
                 </div>
                 <p class="paginator">
                     {% for p in page_range %}
-                        {% if p == page %}
-                            <span class="this-page">{{ p }}</span>
-                        {% elif forloop.last %}
-                            <a href="?page={{ p }}" class="end">{{ p }}</a>
-                        {% else %}
-                            <a href="?page={{ p }}">{{ p }}</a>
-                        {% endif %}
+                        {% if p == page %}<span class="this-page">{{ p }}</span>
+                        {% elif forloop.last %}<a href="?page={{ p }}" class="end">{{ p }}</a>
+                        {% else %}<a href="?page={{ p }}">{{ p }}</a>{% endif %}
                     {% endfor %}
                     {{ num_jobs }} jobs
                 </p>
@@ -151,5 +188,7 @@
         </div>
     </div>
 </div>
+
+{% endif %}
 
 {% endblock %}

--- a/django_rq/templates/django_rq/scheduler.html
+++ b/django_rq/templates/django_rq/scheduler.html
@@ -6,7 +6,9 @@
 
 {% block extrastyle %}
     {{ block.super }}
+    {% if not unfold_installed %}
     <link rel="stylesheet" type="text/css" href="{% static "admin/css/changelists.css" %}">
+    {% endif %}
 {% endblock %}
 
 {% block extrahead %}
@@ -23,7 +25,6 @@
     </script>
 {% endblock %}
 
-
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
@@ -35,9 +36,72 @@
 
 {% block content %}
 
+{% if unfold_installed %}
+
+<h1 class="font-semibold mb-4 text-xl text-font-important-light dark:text-font-important-dark">Scheduler Managed Jobs</h1>
+
+<form id="changelist-form" action="" method="post">
+    {% csrf_token %}
+    <div class="flex gap-2 items-center mb-4">
+        <select name="action" class="border border-base-200 dark:border-base-800 rounded-default bg-white dark:bg-base-900 px-3 py-2 text-sm">
+            <option value="" selected>---------</option>
+            <option value="delete">Delete</option>
+        </select>
+        <button type="submit" class="bg-primary-600 cursor-pointer font-medium hover:bg-primary-500 px-3 py-2 rounded-default text-sm text-white" name="index" value="0">Go</button>
+    </div>
+    <div class="overflow-x-auto rounded-default border border-base-200 dark:border-base-800 mb-4">
+        <table class="w-full">
+            <thead class="bg-base-100 dark:bg-base-800">
+                <tr>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark w-px">
+                        <input type="checkbox" id="action-toggle" class="rounded" style="display: inline-block;">
+                    </th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">ID</th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Schedule</th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Next Run</th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Last Ended</th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Last Status</th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Callable</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for job in jobs %}
+                <tr class="border-t border-base-200 dark:border-base-800 hover:bg-base-50 dark:hover:bg-base-800/50">
+                    <td class="p-3 px-4">
+                        <input class="action-select rounded" name="_selected_action" type="checkbox" value="{{ job.id }}">
+                    </td>
+                    <td class="p-3 px-4 text-sm">
+                        <a href="{% rq_url 'job_detail' job.queue_index job.id %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400 font-mono text-xs">{{ job.id }}</a>
+                    </td>
+                    <td class="p-3 px-4 text-sm">{{ job.schedule }}</td>
+                    <td class="p-3 px-4 text-sm whitespace-nowrap">
+                        {% if job.next_run %}{{ job.next_run|to_localtime|date:"Y-m-d, H:i:s" }}{% endif %}
+                    </td>
+                    <td class="p-3 px-4 text-sm whitespace-nowrap">
+                        {% if job.ended_at %}{{ job.ended_at|to_localtime|date:"Y-m-d, H:i:s" }}{% endif %}
+                    </td>
+                    <td class="p-3 px-4 text-sm">{{ job.get_status.value }}</td>
+                    <td class="p-3 px-4 text-sm font-mono text-xs">{{ job|show_func_name }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <div class="flex gap-1 items-center text-sm">
+        {% for p in page_range %}
+            {% if p == page %}
+                <span class="font-medium px-3 py-1 rounded-default bg-primary-600 text-white">{{ p }}</span>
+            {% else %}
+                <a href="?page={{ p }}" class="border border-base-200 dark:border-base-800 hover:bg-base-50 dark:hover:bg-base-800 px-3 py-1 rounded-default">{{ p }}</a>
+            {% endif %}
+        {% endfor %}
+        <span class="ml-2 text-font-default-light dark:text-font-default-dark">{{ num_jobs }} jobs</span>
+    </div>
+</form>
+
+{% else %}
+
 <div id="content-main">
-    <ul class="object-tools">
-    </ul>
     <div class="module" id="changelist">
         <form id="changelist-form" action="" method="post">
             {% csrf_token %}
@@ -46,9 +110,6 @@
                     <select name="action">
                         <option value="" selected="selected">---------</option>
                         <option value="delete">Delete</option>
-                        {% if job_status == 'Failed' %}
-                            <option value="requeue">Requeue</option>
-                        {% endif %}
                     </select>
                 </label>
                 <button type="submit" class="button" title="Execute selected action" name="index" value="0">Go</button>
@@ -58,30 +119,22 @@
                     <thead>
                         <tr>
                             <th scope="col" class="action-checkbox-column">
-                                <div class="text">
-                                    <span><input type="checkbox" id="action-toggle" style="display: inline-block;"></span>
-                                </div>
+                                <div class="text"><span><input type="checkbox" id="action-toggle" style="display: inline-block;"></span></div>
                                 <div class="clear"></div>
                             </th>
-                            <th><div class = 'text'><span>ID</span></div></th>
-                            <th><div class = 'text'><span>Schedule</span></div></th>
-                            <th><div class = 'text'><span>Next Run</span></div></th>
-                            <th><div class = 'text'><span>Last Ended</span></div></th>
-                            <th><div class = 'text'><span>Last Status</span></div></th>
-                            <th><div class = 'text'><span>Callable</span></div></th>
+                            <th><div class="text"><span>ID</span></div></th>
+                            <th><div class="text"><span>Schedule</span></div></th>
+                            <th><div class="text"><span>Next Run</span></div></th>
+                            <th><div class="text"><span>Last Ended</span></div></th>
+                            <th><div class="text"><span>Last Status</span></div></th>
+                            <th><div class="text"><span>Callable</span></div></th>
                         </tr>
                     </thead>
                     <tbody>
                         {% for job in jobs %}
-                            <tr class = "{% cycle 'row1' 'row2' %}">
-                                <td class="action-checkbox">
-                                    <input class="action-select" name="_selected_action" type="checkbox" value="{{ job.id }}">
-                                </td>
-                                <td>
-                                    <a href = "{% rq_url 'job_detail' job.queue_index job.id %}">
-                                        {{ job.id }}
-                                    </a>
-                                </td>
+                            <tr class="{% cycle 'row1' 'row2' %}">
+                                <td class="action-checkbox"><input class="action-select" name="_selected_action" type="checkbox" value="{{ job.id }}"></td>
+                                <td><a href="{% rq_url 'job_detail' job.queue_index job.id %}">{{ job.id }}</a></td>
                                 <td>{{ job.schedule }}</td>
                                 <td>
                                     {% if job.next_run %}
@@ -102,18 +155,16 @@
             </div>
             <p class="paginator">
                 {% for p in page_range %}
-                    {% if p == page %}
-                        <span class="this-page">{{ p }}</span>
-                    {% elif forloop.last %}
-                        <a href="?page={{ p }}" class="end">{{ p }}</a>
-                    {% else %}
-                        <a href="?page={{ p }}">{{ p }}</a>
-                    {% endif %}
+                    {% if p == page %}<span class="this-page">{{ p }}</span>
+                    {% elif forloop.last %}<a href="?page={{ p }}" class="end">{{ p }}</a>
+                    {% else %}<a href="?page={{ p }}">{{ p }}</a>{% endif %}
                 {% endfor %}
                 {{ num_jobs }} jobs
             </p>
         </form>
     </div>
 </div>
+
+{% endif %}
 
 {% endblock %}

--- a/django_rq/templates/django_rq/started_job_registry.html
+++ b/django_rq/templates/django_rq/started_job_registry.html
@@ -63,7 +63,6 @@
                     <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Last Heartbeat</th>
                     <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Enqueued</th>
                     <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Callable</th>
-                    {% block extra_columns %}{% endblock extra_columns %}
                 </tr>
             </thead>
             <tbody>
@@ -85,7 +84,6 @@
                         {% if execution.job.enqueued_at %}{{ execution.job.enqueued_at|to_localtime|date:"Y-m-d, H:i:s" }}{% endif %}
                     </td>
                     <td class="p-3 px-4 text-sm font-mono text-xs">{{ execution.job|show_func_name }}</td>
-                    {% block extra_columns_values %}{% endblock extra_columns_values %}
                 </tr>
                 {% endfor %}
             </tbody>

--- a/django_rq/templates/django_rq/started_job_registry.html
+++ b/django_rq/templates/django_rq/started_job_registry.html
@@ -6,7 +6,9 @@
 
 {% block extrastyle %}
     {{ block.super }}
+    {% if not unfold_installed %}
     <link rel="stylesheet" type="text/css" href="{% static "admin/css/changelists.css" %}">
+    {% endif %}
 {% endblock %}
 
 {% block extrahead %}
@@ -23,7 +25,6 @@
     </script>
 {% endblock %}
 
-
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
@@ -36,8 +37,75 @@
 
 {% block content %}
 
-<div id="content-main">
+{% if unfold_installed %}
 
+<h1 class="font-semibold mb-4 text-xl text-font-important-light dark:text-font-important-dark">Job Executions in {{ queue.name }}</h1>
+
+<form id="changelist-form" action="{% rq_url 'confirm_action' queue_index %}" method="post">
+    {% csrf_token %}
+    <div class="flex gap-2 items-center mb-4">
+        <select name="action" class="border border-base-200 dark:border-base-800 rounded-default bg-white dark:bg-base-900 px-3 py-2 text-sm" required>
+            <option value="" selected>---------</option>
+            <option value="delete">Delete</option>
+            <option value="stop">Stop</option>
+        </select>
+        <button type="submit" class="bg-primary-600 cursor-pointer font-medium hover:bg-primary-500 px-3 py-2 rounded-default text-sm text-white" name="index" value="0">Go</button>
+    </div>
+    <div class="overflow-x-auto rounded-default border border-base-200 dark:border-base-800 mb-4">
+        <table class="w-full">
+            <thead class="bg-base-100 dark:bg-base-800">
+                <tr>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark w-px">
+                        <input type="checkbox" id="action-toggle" class="rounded">
+                    </th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Execution ID</th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Created</th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Last Heartbeat</th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Enqueued</th>
+                    <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Callable</th>
+                    {% block extra_columns %}{% endblock extra_columns %}
+                </tr>
+            </thead>
+            <tbody>
+                {% for execution in executions %}
+                <tr class="border-t border-base-200 dark:border-base-800 hover:bg-base-50 dark:hover:bg-base-800/50">
+                    <td class="p-3 px-4">
+                        <input class="action-select rounded" name="_selected_action" type="checkbox" value="{{ execution.job.id }}">
+                    </td>
+                    <td class="p-3 px-4 text-sm">
+                        <a href="{% rq_url 'job_detail' queue_index execution.job_id %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400 font-mono text-xs">{{ execution.id }}</a>
+                    </td>
+                    <td class="p-3 px-4 text-sm whitespace-nowrap">
+                        {% if execution.created_at %}{{ execution.created_at|to_localtime|date:"Y-m-d, H:i:s" }}{% endif %}
+                    </td>
+                    <td class="p-3 px-4 text-sm whitespace-nowrap">
+                        {% if execution.last_heartbeat %}{{ execution.last_heartbeat|to_localtime|date:"Y-m-d, H:i:s" }}{% endif %}
+                    </td>
+                    <td class="p-3 px-4 text-sm whitespace-nowrap">
+                        {% if execution.job.enqueued_at %}{{ execution.job.enqueued_at|to_localtime|date:"Y-m-d, H:i:s" }}{% endif %}
+                    </td>
+                    <td class="p-3 px-4 text-sm font-mono text-xs">{{ execution.job|show_func_name }}</td>
+                    {% block extra_columns_values %}{% endblock extra_columns_values %}
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <div class="flex gap-1 items-center text-sm">
+        {% for p in page_range %}
+            {% if p == page %}
+                <span class="font-medium px-3 py-1 rounded-default bg-primary-600 text-white">{{ p }}</span>
+            {% else %}
+                <a href="?page={{ p }}" class="border border-base-200 dark:border-base-800 hover:bg-base-50 dark:hover:bg-base-800 px-3 py-1 rounded-default">{{ p }}</a>
+            {% endif %}
+        {% endfor %}
+        <span class="ml-2 text-font-default-light dark:text-font-default-dark">{{ num_jobs }} jobs</span>
+    </div>
+</form>
+
+{% else %}
+
+<div id="content-main">
     <div class="module" id="changelist">
         <div class="changelist-form-container">
             <form id="changelist-form" action="{% rq_url 'confirm_action' queue_index %}" method="post">
@@ -57,36 +125,18 @@
                         <thead>
                             <tr>
                                 <th scope="col" class="action-checkbox-column">
-                                    <div class="text">
-                                        <span><input type="checkbox" id="action-toggle"></span>
-                                    </div>
+                                    <div class="text"><span><input type="checkbox" id="action-toggle"></span></div>
                                     <div class="clear"></div>
                                 </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>Execution ID</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>Created</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>Last Heartbeat</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>Enqueued</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class='text'><span>Callable</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                {% block extra_columns %}
-                                {% endblock extra_columns %}
+                                <th scope="col" class="sortable"><div class="text"><span>Execution ID</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Created</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Last Heartbeat</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Enqueued</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Callable</span></div><div class="clear"></div></th>
+                                {% block extra_columns %}{% endblock extra_columns %}
                             </tr>
                         </thead>
-                        <tbody>                           
+                        <tbody>
                             {% for execution in executions %}
                                 <tr>
                                     <td class="action-checkbox">
@@ -113,8 +163,7 @@
                                         {% endif %}
                                     </td>
                                     <td>{{ execution.job|show_func_name }}</td>
-                                    {% block extra_columns_values %}
-                                    {% endblock extra_columns_values %}
+                                    {% block extra_columns_values %}{% endblock extra_columns_values %}
                                 </tr>
                             {% endfor %}
                         </tbody>
@@ -122,13 +171,9 @@
                 </div>
                 <p class="paginator">
                     {% for p in page_range %}
-                        {% if p == page %}
-                            <span class="this-page">{{ p }}</span>
-                        {% elif forloop.last %}
-                            <a href="?page={{ p }}" class="end">{{ p }}</a>
-                        {% else %}
-                            <a href="?page={{ p }}">{{ p }}</a>
-                        {% endif %}
+                        {% if p == page %}<span class="this-page">{{ p }}</span>
+                        {% elif forloop.last %}<a href="?page={{ p }}" class="end">{{ p }}</a>
+                        {% else %}<a href="?page={{ p }}">{{ p }}</a>{% endif %}
                     {% endfor %}
                     {{ num_jobs }} jobs
                 </p>
@@ -136,5 +181,7 @@
         </div>
     </div>
 </div>
+
+{% endif %}
 
 {% endblock %}

--- a/django_rq/templates/django_rq/stats.html
+++ b/django_rq/templates/django_rq/stats.html
@@ -1,16 +1,6 @@
 {% extends "admin/base_site.html" %}
 {% load static django_rq %}
 
-{% block extrastyle %}
-    {{ block.super }}
-    <link rel="stylesheet" type="text/css" href="{% static "admin/css/changelists.css" %}">
-    <style>
-        #changelist table thead th:first-child {
-            width: inherit
-        }
-    </style>
-{% endblock %}
-
 {% block title %}Queues{% endblock %}
 
 {% block content_title %}<h1>Queues</h1>{% endblock %}
@@ -22,116 +12,186 @@
     </div>
 {% endblock %}
 
+{% block extrastyle %}
+    {{ block.super }}
+    {% if not unfold_installed %}
+    <link rel="stylesheet" type="text/css" href="{% static "admin/css/changelists.css" %}">
+    <style>
+        #changelist table thead th:first-child { width: inherit }
+    </style>
+    {% endif %}
+{% endblock %}
+
 {% block content %}
+
+{% if unfold_installed %}
+
+<h1 class="font-semibold mb-4 text-xl text-font-important-light dark:text-font-important-dark">Queues</h1>
+
+<div class="overflow-x-auto rounded-default border border-base-200 dark:border-base-800 mb-6">
+    <table class="w-full">
+        <thead class="bg-base-100 dark:bg-base-800">
+            <tr>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Name</th>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Queued Jobs</th>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Oldest Queued Job</th>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Active Jobs</th>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Deferred Jobs</th>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Finished Jobs</th>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Failed Jobs</th>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Scheduled Jobs</th>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Workers</th>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Host</th>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Port</th>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">DB</th>
+                {% if queue.scheduler_pid is not False %}
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark whitespace-nowrap">Scheduler PID</th>
+                {% endif %}
+            </tr>
+        </thead>
+        <tbody>
+            {% for queue in queues %}
+            <tr class="border-t border-base-200 dark:border-base-800 hover:bg-base-50 dark:hover:bg-base-800/50">
+                <td class="p-3 px-4 text-sm font-medium">
+                    <a href="{% rq_url 'jobs' queue.index %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400">{{ queue.name }}</a>
+                </td>
+                <td class="p-3 px-4 text-sm">
+                    <a href="{% rq_url 'jobs' queue.index %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400">{{ queue.jobs }}</a>
+                </td>
+                <td class="p-3 px-4 text-sm">{{ queue.oldest_job_timestamp }}</td>
+                <td class="p-3 px-4 text-sm">
+                    <a href="{% rq_url 'started_jobs' queue.index %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400">{{ queue.started_jobs }}</a>
+                </td>
+                <td class="p-3 px-4 text-sm">
+                    <a href="{% rq_url 'deferred_jobs' queue.index %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400">{{ queue.deferred_jobs }}</a>
+                </td>
+                <td class="p-3 px-4 text-sm">
+                    <a href="{% rq_url 'finished_jobs' queue.index %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400">{{ queue.finished_jobs }}</a>
+                </td>
+                <td class="p-3 px-4 text-sm">
+                    <a href="{% rq_url 'failed_jobs' queue.index %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400">{{ queue.failed_jobs }}</a>
+                </td>
+                <td class="p-3 px-4 text-sm">
+                    <a href="{% rq_url 'scheduled_jobs' queue.index %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400">{{ queue.scheduled_jobs }}</a>
+                </td>
+                <td class="p-3 px-4 text-sm">
+                    <a href="{% rq_url 'workers' queue.index %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400">{{ queue.workers }}</a>
+                </td>
+                <td class="p-3 px-4 text-sm">{{ queue.connection_kwargs.host }}</td>
+                <td class="p-3 px-4 text-sm">{{ queue.connection_kwargs.port }}</td>
+                <td class="p-3 px-4 text-sm">{{ queue.connection_kwargs.db }}</td>
+                {% if queue.scheduler_pid is not False %}
+                <td class="p-3 px-4 text-sm">{{ queue.scheduler_pid|default_if_none:"Inactive" }}</td>
+                {% endif %}
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+
+<div class="flex flex-wrap gap-2 mb-8">
+    <a href="{% rq_url 'home_json' %}" class="border border-base-200 dark:border-base-800 font-medium hover:bg-base-50 dark:hover:bg-base-800 px-3 py-2 rounded-default text-sm">View as JSON</a>
+    {% if view_metrics %}
+    <a href="{% rq_url 'metrics' %}" class="border border-base-200 dark:border-base-800 font-medium hover:bg-base-50 dark:hover:bg-base-800 px-3 py-2 rounded-default text-sm">View Metrics</a>
+    {% endif %}
+</div>
+
+<h2 class="font-semibold mb-4 text-base text-font-important-light dark:text-font-important-dark">Cron Schedulers</h2>
+
+{% if cron_schedulers %}
+<div class="overflow-x-auto rounded-default border border-base-200 dark:border-base-800 mb-8">
+    <table class="w-full">
+        <thead class="bg-base-100 dark:bg-base-800">
+            <tr>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Name</th>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Host</th>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Port</th>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">DB</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for cron_scheduler in cron_schedulers %}
+            <tr class="border-t border-base-200 dark:border-base-800 hover:bg-base-50 dark:hover:bg-base-800/50">
+                <td class="p-3 px-4 text-sm">
+                    <a href="{% rq_url 'cron_scheduler_detail' cron_scheduler.connection_index cron_scheduler.name %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400">{{ cron_scheduler.name }}</a>
+                </td>
+                <td class="p-3 px-4 text-sm">{{ cron_scheduler.connection.connection_pool.connection_kwargs.host }}</td>
+                <td class="p-3 px-4 text-sm">{{ cron_scheduler.connection.connection_pool.connection_kwargs.port }}</td>
+                <td class="p-3 px-4 text-sm">{{ cron_scheduler.connection.connection_pool.connection_kwargs.db }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% else %}
+<p class="mb-8 text-sm text-font-default-light dark:text-font-default-dark">No running cron schedulers</p>
+{% endif %}
+
+{% if schedulers %}
+<h2 class="font-semibold mb-4 text-base text-font-important-light dark:text-font-important-dark">RQ Scheduler</h2>
+<div class="overflow-x-auto rounded-default border border-base-200 dark:border-base-800 mb-8">
+    <table class="w-full">
+        <thead class="bg-base-100 dark:bg-base-800">
+            <tr>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Redis Connection</th>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Recurring Jobs</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for connection, scheduler in schedulers.items %}
+            <tr class="border-t border-base-200 dark:border-base-800 hover:bg-base-50 dark:hover:bg-base-800/50">
+                <td class="p-3 px-4 text-sm">
+                    <a href="{% rq_url 'scheduler_jobs' scheduler.index %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400">{{ connection }}</a>
+                </td>
+                <td class="p-3 px-4 text-sm">
+                    <a href="{% rq_url 'scheduler_jobs' scheduler.index %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400">{{ scheduler.count }}</a>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+{% endif %}
+
+{% else %}
 
 <div id="content-main">
     <div class="module" id="changelist">
         <div class="changelist-form-container">
-            <form id="changelist-form" method="post" {% if cl.formset and cl.formset.is_multipart %}
-                enctype="multipart/form-data" {% endif %} novalidate>{% csrf_token %}
+            <form id="changelist-form" method="post" novalidate>{% csrf_token %}
                 <div class="results">
                     <table id="results_list">
                         <thead>
                             <tr>
-                                <th scope="col" class="sortable">
-                                    <div class="text"><span>Name</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class="text"><span>Queued Jobs</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class="text"><span>Oldest Queued Job</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class="text"><span>Active Jobs</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class="text"><span>Deferred Jobs</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class="text"><span>Finished Jobs</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class="text"><span>Failed Jobs</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class="text"><span>Scheduled Jobs</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class="text"><span>Workers</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class="text"><span>Host</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class="text"><span>Port</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                <th scope="col" class="sortable">
-                                    <div class="text"><span>DB</span></div>
-                                    <div class="clear"></div>
-                                </th>
+                                <th scope="col" class="sortable"><div class="text"><span>Name</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Queued Jobs</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Oldest Queued Job</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Active Jobs</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Deferred Jobs</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Finished Jobs</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Failed Jobs</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Scheduled Jobs</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Workers</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Host</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>Port</span></div><div class="clear"></div></th>
+                                <th scope="col" class="sortable"><div class="text"><span>DB</span></div><div class="clear"></div></th>
                                 {% if queue.scheduler_pid is not False %}
-                                <th scope="col" class="sortable">
-                                    <div class="text"><span>Scheduler PID</span></div>
-                                    <div class="clear"></div>
-                                </th>
-                                {% endif%}
+                                <th scope="col" class="sortable"><div class="text"><span>Scheduler PID</span></div><div class="clear"></div></th>
+                                {% endif %}
                             </tr>
                         </thead>
                         <tbody>
                             {% for queue in queues %}
                             <tr class="{% cycle 'row1' 'row2' %}">
-                                <th>
-                                    <a href="{% rq_url 'jobs' queue.index %}">
-                                        {{ queue.name }}
-                                    </a>
-                                </th>
-                                <th>
-                                    <a href="{% rq_url 'jobs' queue.index %}">
-                                        {{ queue.jobs }}
-                                    </a>
-                                </th>
+                                <th><a href="{% rq_url 'jobs' queue.index %}">{{ queue.name }}</a></th>
+                                <th><a href="{% rq_url 'jobs' queue.index %}">{{ queue.jobs }}</a></th>
                                 <td>{{ queue.oldest_job_timestamp }}</td>
-                                <th>
-                                    <a href="{% rq_url 'started_jobs' queue.index %}">
-                                        {{ queue.started_jobs }}
-                                    </a>
-                                </th>
-                                <th>
-                                    <a href="{% rq_url 'deferred_jobs' queue.index %}">
-                                        {{ queue.deferred_jobs }}
-                                    </a>
-                                </th>
-                                <th>
-                                    <a href="{% rq_url 'finished_jobs' queue.index %}">
-                                        {{ queue.finished_jobs }}
-                                    </a>
-                                </th>
-                                <th>
-                                    <a href="{% rq_url 'failed_jobs' queue.index %}">
-                                        {{ queue.failed_jobs }}
-                                    </a>
-                                </th>
-                                <th>
-                                    <a href="{% rq_url 'scheduled_jobs' queue.index %}">
-                                        {{ queue.scheduled_jobs }}
-                                    </a>
-                                </th>
-                                <th><a href="{% rq_url 'workers' queue.index %}">
-                                        {{ queue.workers }}
-                                    </a>
-                                </th>
+                                <th><a href="{% rq_url 'started_jobs' queue.index %}">{{ queue.started_jobs }}</a></th>
+                                <th><a href="{% rq_url 'deferred_jobs' queue.index %}">{{ queue.deferred_jobs }}</a></th>
+                                <th><a href="{% rq_url 'finished_jobs' queue.index %}">{{ queue.finished_jobs }}</a></th>
+                                <th><a href="{% rq_url 'failed_jobs' queue.index %}">{{ queue.failed_jobs }}</a></th>
+                                <th><a href="{% rq_url 'scheduled_jobs' queue.index %}">{{ queue.scheduled_jobs }}</a></th>
+                                <th><a href="{% rq_url 'workers' queue.index %}">{{ queue.workers }}</a></th>
                                 <td>{{ queue.connection_kwargs.host }}</td>
                                 <td>{{ queue.connection_kwargs.port }}</td>
                                 <td>{{ queue.connection_kwargs.db }}</td>
@@ -145,9 +205,9 @@
                 </div>
                 <p class="paginator">
                     <a href="{% rq_url 'home_json' %}" class="showall">View as JSON</a>
-                {% if view_metrics %}
+                    {% if view_metrics %}
                     <a href="{% rq_url 'metrics' %}" class="showall">View Metrics</a>
-                {% endif %}
+                    {% endif %}
                 </p>
             </form>
         </div>
@@ -160,9 +220,7 @@
             <table id="result_list">
                 <thead>
                     <tr>
-                        <th>
-                            <div class="text"><span>Name</span></div>
-                        </th>
+                        <th><div class="text"><span>Name</span></div></th>
                         <th><div class="text"><span>Host</span></div></th>
                         <th><div class="text"><span>Port</span></div></th>
                         <th><div class="text"><span>DB</span></div></th>
@@ -203,5 +261,7 @@
     </table>
     {% endif %}
 </div>
+
+{% endif %}
 
 {% endblock %}

--- a/django_rq/templates/django_rq/worker_details.html
+++ b/django_rq/templates/django_rq/worker_details.html
@@ -4,6 +4,7 @@
 
 {% block extrastyle %}
     {{ block.super }}
+    {% if not unfold_installed %}
     <style>
         .data {
             display: inline-block;
@@ -14,14 +15,15 @@
         }
     </style>
     <link href="{% static 'admin/css/forms.css' %}" type="text/css" rel="stylesheet">
+    {% endif %}
 {% endblock %}
 
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
         <a href="{% rq_url 'home' %}">Django RQ</a> &rsaquo;
-        <a href = "{% rq_url 'workers' queue_index %}">{{ queue.name }} Workers</a> &rsaquo;
-        <a href = "{% rq_url 'worker_details' queue_index worker.name %}">{{ worker.name }}</a>
+        <a href="{% rq_url 'workers' queue_index %}">{{ queue.name }} Workers</a> &rsaquo;
+        <a href="{% rq_url 'worker_details' queue_index worker.name %}">{{ worker.name }}</a>
     </div>
 {% endblock %}
 
@@ -29,87 +31,132 @@
 
 {% block content %}
 
+{% if unfold_installed %}
+
+<h1 class="font-semibold mb-4 text-xl text-font-important-light dark:text-font-important-dark">Worker Info</h1>
+
+<div class="border border-base-200 dark:border-base-800 rounded-default mb-8 overflow-hidden">
+    <div class="flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-48 text-font-default-light dark:text-font-default-dark text-sm">Name</span>
+        <span class="text-sm">{{ worker.name }}</span>
+    </div>
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-48 text-font-default-light dark:text-font-default-dark text-sm">State</span>
+        <span class="text-sm">{{ worker.get_state }}</span>
+    </div>
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-48 text-font-default-light dark:text-font-default-dark text-sm">Birth</span>
+        <span class="text-sm">{{ worker.birth_date|to_localtime|date:"Y-m-d, H:i:s" }}</span>
+    </div>
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-48 text-font-default-light dark:text-font-default-dark text-sm">Queues</span>
+        <span class="text-sm">{{ queue_names }}</span>
+    </div>
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-48 text-font-default-light dark:text-font-default-dark text-sm">PID</span>
+        <span class="text-sm">{{ worker.pid }}</span>
+    </div>
+    {% if job %}
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-48 text-font-default-light dark:text-font-default-dark text-sm">Current Job</span>
+        <span class="text-sm">
+            {{ job.func_name }}
+            (<a href="{% rq_url 'job_detail' queue_index job.id %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400">{{ job.id }}</a>)
+        </span>
+    </div>
+    {% endif %}
+    {% if worker.successful_job_count != None %}
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-48 text-font-default-light dark:text-font-default-dark text-sm">Successful job count</span>
+        <span class="text-sm">{{ worker.successful_job_count }}</span>
+    </div>
+    {% endif %}
+    {% if worker.failed_job_count != None %}
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-48 text-font-default-light dark:text-font-default-dark text-sm">Failed job count</span>
+        <span class="text-sm">{{ worker.failed_job_count }}</span>
+    </div>
+    {% endif %}
+    {% if worker.total_working_time != None %}
+    <div class="border-t border-base-200 dark:border-base-800 flex gap-4 items-baseline p-3 px-4">
+        <span class="font-semibold min-w-48 text-font-default-light dark:text-font-default-dark text-sm">Total working time (seconds)</span>
+        <span class="text-sm">{{ total_working_time }}</span>
+    </div>
+    {% endif %}
+</div>
+
+{% else %}
+
 <div id="content-main">
-
-    <fieldset class="module aligned ">
-
+    <fieldset class="module aligned">
         <div class="form-row">
             <div>
                 <label class="required">Name:</label>
                 <div class="data">{{ worker.name }}</div>
             </div>
         </div>
-
         <div class="form-row">
             <div>
                 <label class="required">State:</label>
                 <div class="data">{{ worker.get_state }}</div>
             </div>
         </div>
-
         <div class="form-row">
             <div>
                 <label class="required">Birth:</label>
                 <div class="data">{{ worker.birth_date|timestamp_tooltip }}</div>
             </div>
         </div>
-
         <div class="form-row">
             <div>
                 <label class="required">Queues:</label>
                 <div class="data">{{ queue_names }}</div>
             </div>
         </div>
-
         <div class="form-row">
             <div>
                 <label class="required">PID:</label>
                 <div class="data">{{ worker.pid }}</div>
             </div>
         </div>
-
         {% if job %}
         <div class="form-row">
             <div>
                 <label class="required">Current Job:</label>
                 <div class="data">
                     {{ job.func_name }}
-                    (<a href = "{% rq_url 'job_detail' queue_index job.id %}">{{ job.id }}</a>)
+                    (<a href="{% rq_url 'job_detail' queue_index job.id %}">{{ job.id }}</a>)
                 </div>
             </div>
         </div>
-
         {% endif %}
-
         {% if worker.successful_job_count != None %}
-            <div class="form-row">
-                <div>
-                    <label class="required">Successful job count:</label>
-                    <div class="data">{{ worker.successful_job_count }}</div>
-                </div>
+        <div class="form-row">
+            <div>
+                <label class="required">Successful job count:</label>
+                <div class="data">{{ worker.successful_job_count }}</div>
             </div>
+        </div>
         {% endif %}
-
         {% if worker.failed_job_count != None %}
-            <div class="form-row">
-                <div>
-                    <label class="required">Failed job count:</label>
-                    <div class="data">{{ worker.failed_job_count }}</div>
-                </div>
+        <div class="form-row">
+            <div>
+                <label class="required">Failed job count:</label>
+                <div class="data">{{ worker.failed_job_count }}</div>
             </div>
+        </div>
         {% endif %}
-
         {% if worker.total_working_time != None %}
-            <div class="form-row">
-                <div>
-                    <label class="required">Total working time (seconds):</label>
-                    <div class="data">{{ total_working_time }}</div>
-                </div>
+        <div class="form-row">
+            <div>
+                <label class="required">Total working time (seconds):</label>
+                <div class="data">{{ total_working_time }}</div>
             </div>
+        </div>
         {% endif %}
-
     </fieldset>
-
 </div>
+
+{% endif %}
 
 {% endblock %}

--- a/django_rq/templates/django_rq/workers.html
+++ b/django_rq/templates/django_rq/workers.html
@@ -6,7 +6,9 @@
 
 {% block extrastyle %}
     {{ block.super }}
+    {% if not unfold_installed %}
     <link rel="stylesheet" type="text/css" href="{% static "admin/css/changelists.css" %}">
+    {% endif %}
 {% endblock %}
 
 {% block extrahead %}
@@ -23,18 +25,48 @@
     </script>
 {% endblock %}
 
-
 {% block breadcrumbs %}
     <div class="breadcrumbs">
         <a href="{% url 'admin:index' %}">Home</a> &rsaquo;
         <a href="{% rq_url 'home' %}">Django RQ</a> &rsaquo;
-        <a href = "{% rq_url 'jobs' queue_index %}">{{ queue.name }} Workers</a>
+        <a href="{% rq_url 'jobs' queue_index %}">{{ queue.name }} Workers</a>
     </div>
 {% endblock %}
 
 {% block content_title %}<h1>Workers in {{ queue.name }}</h1>{% endblock %}
 
 {% block content %}
+
+{% if unfold_installed %}
+
+<h1 class="font-semibold mb-4 text-xl text-font-important-light dark:text-font-important-dark">Workers in {{ queue.name }}</h1>
+
+<div class="overflow-x-auto rounded-default border border-base-200 dark:border-base-800 mb-8">
+    <table class="w-full">
+        <thead class="bg-base-100 dark:bg-base-800">
+            <tr>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Name</th>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">State</th>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">Birth</th>
+                <th class="font-semibold p-3 px-4 text-left text-sm text-font-default-light dark:text-font-default-dark">PID</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for worker in workers %}
+            <tr class="border-t border-base-200 dark:border-base-800 hover:bg-base-50 dark:hover:bg-base-800/50">
+                <td class="p-3 px-4 text-sm font-medium">
+                    <a href="{% rq_url 'worker_details' queue_index worker.key %}" class="text-primary-600 hover:text-primary-500 dark:text-primary-400">{{ worker.name }}</a>
+                </td>
+                <td class="p-3 px-4 text-sm">{{ worker.get_state }}</td>
+                <td class="p-3 px-4 text-sm">{{ worker.birth_date|to_localtime|date:"Y-m-d, H:i:s" }}</td>
+                <td class="p-3 px-4 text-sm">{{ worker.pid|unlocalize }}</td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+
+{% else %}
 
 <div id="content-main">
     <div class="module" id="changelist">
@@ -44,19 +76,17 @@
                 <table id="result_list">
                     <thead>
                         <tr>
-                            <th><div class = 'text'><span>Name</span></div></th>
-                            <th><div class = 'text'><span>State</span></div></th>
-                            <th><div class = 'text'><span>Birth</span></div></th>
-                            <th><div class = 'text'><span>PID</span></div></th>
+                            <th><div class="text"><span>Name</span></div></th>
+                            <th><div class="text"><span>State</span></div></th>
+                            <th><div class="text"><span>Birth</span></div></th>
+                            <th><div class="text"><span>PID</span></div></th>
                         </tr>
                     </thead>
                     <tbody>
                         {% for worker in workers %}
-                            <tr class = "{% cycle 'row1' 'row2' %}">
+                            <tr class="{% cycle 'row1' 'row2' %}">
                                 <th>
-                                    <a href = '{% rq_url 'worker_details' queue_index worker.key %}'>
-                                        {{ worker.name }}
-                                    </a>
+                                    <a href="{% rq_url 'worker_details' queue_index worker.key %}">{{ worker.name }}</a>
                                 </th>
                                 <td>
                                     {{ worker.get_state }}
@@ -71,5 +101,7 @@
         </form>
     </div>
 </div>
+
+{% endif %}
 
 {% endblock %}

--- a/django_rq/views.py
+++ b/django_rq/views.py
@@ -34,8 +34,11 @@ def rq_viewname(request: HttpRequest, viewname: str) -> str:
 
 
 def each_context(request: HttpRequest) -> dict[str, Any]:
+    from django.apps import apps
+
     return {
         **admin.site.each_context(request),
+        'unfold_installed': apps.is_installed('unfold'),
     }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ classifiers = [
 [project.optional-dependencies]
 prometheus = ["prometheus_client >= 0.4.0"]
 testing = ["pytest>=7.0", "pytest-django>=4.5"]
+unfold = ["django-unfold"]
 
 [project.urls]
 changelog = "https://github.com/rq/django-rq/blob/master/CHANGELOG.md"


### PR DESCRIPTION
## Summary

This PR adds first-class support for [django-unfold](https://github.com/unfoldadmin/django-unfold), a modern Django admin theme built on Tailwind CSS.

- **New optional extra**: `pip install django-rq[unfold]` installs `django-unfold` alongside django-rq
- **Context variable**: `each_context()` in `views.py` now injects `unfold_installed` (bool) into every template context via `apps.is_installed("unfold")`
- **Dual-mode templates**: All 17 admin templates now contain two rendering branches:
  - `{% if unfold_installed %}` — Tailwind CSS utility classes matching unfold's design system (dark mode, hover states, responsive layout)
  - `{% else %}` — original Django admin CSS markup (unchanged, fully backward-compatible)
- **No CSS conflicts**: `admin/css/changelists.css` and `admin/css/forms.css` are conditionally skipped when unfold is active

## Motivation

django-rq's admin views use standard Django admin CSS classes (`.module`, `#result_list`, `row1`/`row2`, etc.) which are not styled by django-unfold. When unfold is installed, all django-rq admin pages appear unstyled. This PR fixes that without breaking the standard admin experience.

## Usage

```bash
pip install django-rq[unfold]
```

```python
INSTALLED_APPS = [
    "unfold",
    "django.contrib.admin",
    ...
    "django_rq",
]
```

## Screenshots (with django-unfold, dark mode)

**Queues overview**
![Queues overview](https://github.com/sergei-vasilev-dev/django-rq/releases/download/untagged-d5ae9f53f433584c668b/01-queues.png)

**Finished jobs list**
![Finished jobs list](https://github.com/sergei-vasilev-dev/django-rq/releases/download/untagged-d5ae9f53f433584c668b/02-finished-jobs.png)

**Failed jobs list**
![Failed jobs list](https://github.com/sergei-vasilev-dev/django-rq/releases/download/untagged-d5ae9f53f433584c668b/03-failed-jobs.png)


**Job detail — failed (with traceback)**
![Job detail failed](https://github.com/sergei-vasilev-dev/django-rq/releases/download/untagged-d5ae9f53f433584c668b/05-job-detail-failed.png)

## Test plan

- [ ] `pip install django-rq[unfold]`, add `"unfold"` before `"django.contrib.admin"` in `INSTALLED_APPS` — verify all views render with unfold styles
- [ ] Without unfold installed — verify views render identically to before this PR
- [ ] Dark mode rendering with unfold active
- [ ] All pages: queues, workers, finished/failed/scheduled/deferred jobs, scheduler, cron scheduler detail

Generated with [Claude Code](https://claude.com/claude-code)