### PR TITLE
Dropped support for Python 3.9.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE.txt"]
 authors = [{ name = "Selwin Ong", email = "selwin.ong@gmail.com" }]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = ["django>=4.2", "rq>=2.6.1", "redis>=3.5"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -24,8 +24,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
see https://www.djangoproject.com/download/

I think we should drop support for django 4.2, django 5.0 and django 5.1 bcs they reached to their EOL  and by virtue of it we need to drop python 3.9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Python version requirement from 3.9 to 3.10. Support for Python 3.8 and 3.9 has been discontinued.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->