### PR TITLE
Security: Timing-Safe Comparison Not Used for URL Token Parameter

### DIFF
--- a/django_rq/stats_views.py
+++ b/django_rq/stats_views.py
@@ -77,7 +77,7 @@ def stats(request: HttpRequest) -> HttpResponse:
 def stats_json(request: HttpRequest, token: Optional[str] = None) -> JsonResponse:
     if not is_authorized(request):
         api_token = django_rq_settings.get_api_token()
-        if token and token == api_token:
+        if token and compare_digest(token, api_token):
             return JsonResponse(get_statistics())
         else:
             return JsonResponse(


### PR DESCRIPTION
## Summary

Security: Timing-Safe Comparison Not Used for URL Token Parameter

## Problem

**Severity**: `High` | **File**: `django_rq/stats_views.py:L46`

In stats_views.py, the stats_json view accepts a token as a URL parameter (e.g., /stats.json/<token>). When checking this token, it uses direct string comparison (`token == api_token`) instead of timing-safe comparison. This creates a timing attack vulnerability where an attacker could potentially guess the API token by measuring response times.

## Solution

Use `secrets.compare_digest()` for the token comparison instead of direct string equality. Change `if token and token == api_token:` to `if token and compare_digest(token, api_token):`

## Changes

- `django_rq/stats_views.py` (modified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security of bearer token verification in API authentication.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rq/django-rq/pull/792)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->