### PR TITLE
Return 404 for missing queue detail

### DIFF
--- a/django_rq/views.py
+++ b/django_rq/views.py
@@ -82,7 +82,11 @@ def jobs(request: HttpRequest, queue_index: int) -> HttpResponse:
 @never_cache
 @staff_member_required
 def queue_details(request: HttpRequest, queue_index: int) -> HttpResponse:
-    queue = get_queue_by_index(queue_index)
+    try:
+        queue = get_queue_by_index(queue_index)
+    except IndexError:
+        raise Http404(f"Couldn't find queue with this ID: {queue_index}")
+
     connection = queue.connection
     queue_config = get_queues_list()[queue_index]['connection_config']
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,6 +1,7 @@
 import uuid
 from datetime import datetime
 
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.test import TestCase, override_settings
 from django.test.client import Client
@@ -56,6 +57,12 @@ class ViewTest(TestCase):
         self.assertEqual(response.context['num_jobs'], 1)
         self.assertIn('host', response.context['connection_kwargs'])
         self.assertNotIn('password', response.context['connection_kwargs'])
+
+    def test_queue_details_404_for_missing_queue(self):
+        """Queue detail page returns 404 when queue does not exist."""
+        queue_count = len(settings.RQ_QUEUES)
+        response = self.client.get(reverse('admin:django_rq_queue_details', args=[queue_count]))
+        self.assertEqual(response.status_code, 404)
 
     def test_job_details(self):
         """Job data is displayed properly"""


### PR DESCRIPTION
Fixes #804 

Adds a `try`/`except` guard to `get_queue_by_index`, which in turn requests an unvalidated indexed value from the queues.

Adds a simple test that is robust against additions to the number of configured test queues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid queue detail URLs now return a proper 404 error instead of failing unexpectedly.
  * Improved handling for missing queues when viewing queue details in the admin interface.

* **Tests**
  * Added coverage to verify the queue details page returns 404 for non-existent queues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->