### PR TITLE
Display webhooks in job detail and cron page

### DIFF
--- a/django_rq/cron.py
+++ b/django_rq/cron.py
@@ -209,6 +209,7 @@ class DjangoCronScheduler(CronScheduler):
                     "kwargs": job.kwargs,
                     "meta": job_options.get('meta'),
                     "options": options,
+                    "webhooks": job_options.get('webhooks') or [],
                 }
             )
 

--- a/django_rq/templates/django_rq/cron_scheduler_detail.html
+++ b/django_rq/templates/django_rq/cron_scheduler_detail.html
@@ -111,6 +111,7 @@
                         <th><div class="text"><span>Kwargs</span></div></th>
                         <th><div class="text"><span>Meta</span></div></th>
                         <th><div class="text"><span>Options</span></div></th>
+                        <th><div class="text"><span>Webhooks</span></div></th>
                     </tr>
                 </thead>
                 <tbody>
@@ -139,6 +140,13 @@
                         <td>
                             {% for option in cron_job.options %}
                                 {{ option }}{% if not forloop.last %}<br>{% endif %}
+                            {% empty %}
+                                -
+                            {% endfor %}
+                        </td>
+                        <td>
+                            {% for webhook in cron_job.webhooks %}
+                                {{ webhook.job_status }}: {{ webhook.method }} {{ webhook.url }}{% if not forloop.last %}<br>{% endif %}
                             {% empty %}
                                 -
                             {% endfor %}

--- a/django_rq/templates/django_rq/job_detail.html
+++ b/django_rq/templates/django_rq/job_detail.html
@@ -176,6 +176,32 @@
             </div>
             {% endif %}
 
+            {% if job.webhooks %}
+            <div class="rq-panel">
+                <div class="rq-panel-header">Webhooks</div>
+                <table class="rq-table">
+                    <thead>
+                        <tr>
+                            <th>URL</th>
+                            <th>Trigger</th>
+                            <th>Method</th>
+                            <th>Timeout</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for webhook in job.webhooks %}
+                        <tr>
+                            <td class="rq-mono">{{ webhook.url }}</td>
+                            <td>{{ webhook.job_status }}</td>
+                            <td>{{ webhook.method }}</td>
+                            <td>{{ webhook.timeout }}s</td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            {% endif %}
+
             {% if exc_info and job.exc_info %}
             <div class="rq-callout rq-callout-error">
                 <div class="rq-callout-head">

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -202,7 +202,10 @@ class CronViewTest(TestCase):
             ttl=60,
             failure_ttl=120,
         )
-        scheduler.register(say_hello, "default", cron="*/5 * * * *")
+        from rq.webhook import Webhook
+
+        webhook = Webhook('https://example.com/hook', 'failed')
+        scheduler.register(say_hello, "default", cron="*/5 * * * *", webhooks=[webhook])
         scheduler.register_birth()
 
         for prefix in ('admin:django_rq_', 'django_rq:'):
@@ -230,6 +233,12 @@ class CronViewTest(TestCase):
             self.assertContains(response, 'result_ttl=500')
             self.assertContains(response, 'ttl=60')
             self.assertContains(response, 'failure_ttl=120')
+
+            # Webhooks: first job has none, second job's webhook is displayed
+            self.assertEqual(first_cron_job['webhooks'], [])
+            self.assertEqual(response.context['cron_jobs'][1]['webhooks'], [webhook])
+            self.assertContains(response, 'Webhooks')
+            self.assertContains(response, 'failed: GET https://example.com/hook')
 
             # Test 2: Non-existent scheduler returns 404
             url = reverse(f'{prefix}cron_scheduler_detail', args=[connection_index, 'nonexistent-scheduler'])

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -73,6 +73,26 @@ class ViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'DeserializationError')
 
+    def test_job_details_with_webhooks(self):
+        """Job webhooks are displayed on the job detail page (and hidden when absent)"""
+        from rq.webhook import Webhook
+
+        queue = get_queue('default')
+        queue_index = get_queue_index('default')
+
+        webhook = Webhook('https://example.com/hook', 'finished', method='POST', timeout=30)
+        job = queue.enqueue(access_self, webhooks=[webhook])
+        response = self.client.get(reverse('admin:django_rq_job_detail', args=[queue_index, job.id]))
+        self.assertContains(response, 'Webhooks')
+        self.assertContains(response, 'https://example.com/hook')
+        self.assertContains(response, 'finished')
+        self.assertContains(response, 'POST')
+
+        # A job without webhooks doesn't render the panel
+        plain_job = queue.enqueue(access_self)
+        response = self.client.get(reverse('admin:django_rq_job_detail', args=[queue_index, plain_job.id]))
+        self.assertNotContains(response, 'Webhooks')
+
     def test_job_details_with_results(self):
         """Job with results is displayed properly"""
         queue = get_queue('default')


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added webhook details to cron job and job detail views.
  * Cron job lists now show a new Webhooks column.
  * Job pages now display a Webhooks panel when available, including URL, status, method, and timeout.

* **Bug Fixes**
  * Webhook information is now included in job and scheduler data, so it appears correctly in the UI when configured.

* **Tests**
  * Expanded coverage to verify webhook rendering and empty-state behavior in both cron and job detail views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->