### PR TITLE
Rename Django auth permission for Django RQ from "view" to "admin"

### DIFF
--- a/django_rq/migrations/0003_alter_dashboard_permission_names.py
+++ b/django_rq/migrations/0003_alter_dashboard_permission_names.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from django.db import migrations
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+
+def permission_migration(
+    *, old: str, new: str
+) -> Callable[[StateApps, BaseDatabaseSchemaEditor], None]:
+    def migrate(apps: StateApps, schema_editor: BaseDatabaseSchemaEditor) -> None:
+        try:
+            ContentType = apps.get_model("contenttypes", "ContentType")
+            Permission = apps.get_model("auth", "Permission")
+            Dashboard = apps.get_model("django_rq", "Dashboard")
+        except LookupError:
+            return
+
+        Permission._default_manager.filter(
+            content_type=ContentType._default_manager.get_for_model(Dashboard),
+            codename=old,
+        ).update(codename=new)
+
+    return migrate
+
+
+class Migration(migrations.Migration):
+    dependencies = [('django_rq', '0002_delete_queue_create_dashboard')]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='dashboard',
+            options={
+                'default_permissions': (),
+                'managed': False,
+                'permissions': (('admin', 'Access admin page'),),
+                'verbose_name': 'Django-RQ',
+                'verbose_name_plural': 'Django-RQ',
+            },
+        ),
+        migrations.RunPython(
+            permission_migration(old="view", new="admin"),
+            permission_migration(old="admin", new="view"),
+        )
+    ]

--- a/django_rq/models.py
+++ b/django_rq/models.py
@@ -18,6 +18,8 @@ class Dashboard(models.Model):
     class Meta:
         managed = False  # No database table - admin integration only
         default_permissions = ()
-        permissions = [['view', 'Access admin page']]
+        permissions = (
+            ('admin', 'Access admin page'),
+        )
         verbose_name = 'Django-RQ'
         verbose_name_plural = 'Django-RQ'


### PR DESCRIPTION
This change renames the "view" permission to "admin" as the provided Django RQ admin views allow data modification and an admin may incorrectly grant unintended permissions if the codename is used in a query.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dashboard access permissions so the admin page now uses a single, consistent permission label.
  * Existing access rights were migrated to preserve dashboard availability during the change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->