### PR TITLE
`enqueue_at` and `enqueue_in` should respect COMMIT_MODE

### DIFF
--- a/django_rq/queues.py
+++ b/django_rq/queues.py
@@ -1,4 +1,5 @@
 import warnings
+from functools import partial
 from typing import Any, Callable, Optional, Union, cast
 
 from django.conf import settings
@@ -95,22 +96,48 @@ class DjangoRQ(Queue):
 
         super().__init__(*args, **kwargs)
 
-    def original_enqueue_call(self, *args, **kwargs):
-        queue_name = kwargs.get('queue_name') or self.name
-        kwargs['result_ttl'] = kwargs.get('result_ttl', get_result_ttl(queue_name))
+    def enqueue_now(self, django_rq_method: str, *args: Any, **kwargs: Any) -> Job:
+        """
+        Run RQ's own ``enqueue_job`` or ``enqueue_at`` right away, bypassing the
+        commit mode. Used to flush deferred calls (see ``thread_queue``).
+        """
+        return getattr(super(), django_rq_method)(*args, **kwargs)
 
-        return super().enqueue_call(*args, **kwargs)
+    def _enqueue_or_defer(self, django_rq_method: str, *args: Any, **kwargs: Any) -> Optional[Job]:
+        """
+        Run the named RQ method now, or defer it according to this queue's commit mode.
+
+        A caller-supplied ``pipeline`` is never deferred: the caller decides when
+        it executes, and commands appended from a commit hook would land after
+        ``pipeline.execute()`` has already run.
+        """
+        if self._commit_mode == 'auto' or kwargs.get('pipeline') is not None:
+            return self.enqueue_now(django_rq_method, *args, **kwargs)
+        if self._commit_mode == 'on_db_commit':
+            if connection.in_atomic_block:
+                transaction.on_commit(partial(self.enqueue_now, django_rq_method, *args, **kwargs))
+                return None
+            return self.enqueue_now(django_rq_method, *args, **kwargs)
+        thread_queue.add(self, django_rq_method, args, kwargs)
+        return None
 
     def enqueue_call(self, *args, **kwargs):
-        if self._commit_mode == 'auto':
-            return self.original_enqueue_call(*args, **kwargs)
-        elif self._commit_mode == 'on_db_commit':
-            if connection.in_atomic_block:
-                transaction.on_commit(lambda: self.original_enqueue_call(*args, **kwargs))
-            else:
-                return self.original_enqueue_call(*args, **kwargs)
-        else:
-            thread_queue.add(self, args, kwargs)
+        # Only inject the DEFAULT_RESULT_TTL default here. RQ's enqueue_call
+        # creates the job and hands it to enqueue_job, where deferral happens.
+        queue_name = kwargs.get('queue_name') or self.name
+        kwargs['result_ttl'] = kwargs.get('result_ttl', get_result_ttl(queue_name))
+        return super().enqueue_call(*args, **kwargs)
+
+    def enqueue_job(self, job, pipeline=None, at_front=False, unique=False, **kwargs):
+        # Mirror RQ's signature so every argument may arrive positionally, then forward
+        # them all by keyword: _enqueue_or_defer only recognises a pipeline passed as a keyword.
+        return self._enqueue_or_defer('enqueue_job', job, pipeline=pipeline, at_front=at_front, unique=unique, **kwargs)
+
+    def enqueue_at(self, *args, **kwargs):
+        # Also covers enqueue_in(): RQ implements it as self.enqueue_at(now() + delta, ...), so the
+        # target time is resolved here, at call time, and the deferred entry is recorded as 'enqueue_at'.
+        # Positional args after the function are job arguments; pipeline can only be a keyword.
+        return self._enqueue_or_defer('enqueue_at', *args, **kwargs)
 
 
 def get_queue(

--- a/django_rq/thread_queue.py
+++ b/django_rq/thread_queue.py
@@ -9,14 +9,15 @@ _thread_data = threading.local()
 
 def get_queue():
     """
-    Returns a temporary queue to store jobs before they're committed
-    later in the request/response cycle. Each job is stored as a tuple
-    containing the queue, args and kwargs.
+    Returns a temporary queue to store deferred enqueue calls before they're
+    committed later in the request/response cycle. Each entry is a tuple of
+    ``(queue, method_name, args, kwargs)`` where ``method_name`` is the RQ
+    method to run on ``queue`` (``'enqueue_job'`` or ``'enqueue_at'``).
 
-    For example, if we call ``queue.enqueue_call(foo, kwargs={'bar': 'baz'})`` during the
+    For example, if we call ``queue.enqueue(foo, bar='baz')`` during the
     request/response cycle, job_queue will look like:
 
-    job_queue = [(default_queue, foo, {'kwargs': {'bar': 'baz'}})]
+    job_queue = [(default_queue, 'enqueue_job', (<Job ...>,), {'pipeline': None, 'at_front': False, 'unique': False})]
 
     This implementation is heavily inspired by
     https://github.com/chrisdoble/django-celery-transactions
@@ -24,19 +25,19 @@ def get_queue():
     return _thread_data.__dict__.setdefault("job_queue", [])
 
 
-def add(queue: 'DjangoRQ', args: tuple, kwargs: dict) -> None:
-    get_queue().append((queue, args, kwargs))
+def add(queue: 'DjangoRQ', method_name: str, args: tuple, kwargs: dict) -> None:
+    get_queue().append((queue, method_name, args, kwargs))
 
 
 def commit(*args: Any, **kwargs: Any) -> None:
     """
-    Processes all jobs in the delayed queue.
+    Processes all deferred calls in the delayed queue.
     """
     delayed_queue = get_queue()
     try:
         while delayed_queue:
-            queue, args, kwargs = delayed_queue.pop(0)
-            queue.original_enqueue_call(*args, **kwargs)
+            queue, method_name, args, kwargs = delayed_queue.pop(0)
+            queue.enqueue_now(method_name, *args, **kwargs)
     finally:
         clear()
 

--- a/tests/test_commit_modes.py
+++ b/tests/test_commit_modes.py
@@ -1,12 +1,17 @@
+from datetime import datetime, timedelta, timezone
+from unittest import mock
+
 from django.core.exceptions import ImproperlyConfigured
 from django.db import transaction
 from django.test import TestCase, TransactionTestCase, override_settings
 from django.urls import reverse
+from rq.registry import ScheduledJobRegistry
 
 from django_rq import thread_queue
 from django_rq.queues import get_commit_mode, get_queue
 from tests.fixtures import say_hello
 from tests.tests import divide
+from tests.utils import flush_registry
 
 
 class CommitModeTest(TestCase):
@@ -52,7 +57,21 @@ class CommitModeTest(TestCase):
             get_commit_mode()
 
 
+def reset_state(queue):
+    """Empty the queue, its scheduled registry and the thread-local delayed queue."""
+    queue.empty()
+    flush_registry(ScheduledJobRegistry(queue=queue))
+    thread_queue.clear()
+
+
 class ThreadQueueTest(TestCase):
+    """Tests for the request_finished commit mode (the test settings default via AUTOCOMMIT=False)."""
+
+    def setUp(self):
+        queue = get_queue()
+        reset_state(queue)
+        self.addCleanup(reset_state, queue)
+
     @override_settings(RQ={'AUTOCOMMIT': True})
     def test_enqueue_autocommit_on(self):
         """
@@ -60,9 +79,16 @@ class ThreadQueueTest(TestCase):
         immediately persist job into Redis.
         """
         queue = get_queue()
+        registry = ScheduledJobRegistry(queue=queue)
         job = queue.enqueue(divide, 1, 1)
         self.assertTrue(job.id in queue.job_ids)
-        job.delete()
+
+        # The scheduling APIs also run immediately and return the Job
+        scheduled = queue.enqueue_at(datetime(2030, 1, 1, tzinfo=timezone.utc), say_hello)
+        self.assertIn(scheduled.id, registry.get_job_ids())
+        scheduled = queue.enqueue_in(timedelta(minutes=1), say_hello)
+        self.assertIn(scheduled.id, registry.get_job_ids())
+        self.assertEqual(thread_queue.get_queue(), [])
 
     @override_settings(RQ={'AUTOCOMMIT': False})
     def test_enqueue_autocommit_off(self):
@@ -74,14 +100,38 @@ class ThreadQueueTest(TestCase):
         job = queue.enqueue(divide, 1, b=1)
         self.assertTrue(job is None)
         delayed_queue = thread_queue.get_queue()
-        self.assertEqual(delayed_queue[0][0], queue)
-        self.assertEqual(delayed_queue[0][1], ())
-        kwargs = delayed_queue[0][2]
-        self.assertEqual(kwargs['args'], (1,))
-        self.assertEqual(kwargs['result_ttl'], None)
-        self.assertEqual(kwargs['kwargs'], {'b': 1})
-        self.assertEqual(kwargs['func'], divide)
-        self.assertEqual(kwargs['timeout'], None)
+        deferred_queue, method_name, args, kwargs = delayed_queue[0]
+        # The deferred call is RQ's own enqueue_job on this queue
+        self.assertIs(deferred_queue, queue)
+        self.assertEqual(method_name, 'enqueue_job')
+        self.assertEqual(kwargs['pipeline'], None)
+        # The Job is created at call time; only the Redis write is deferred
+        deferred_job = args[0]
+        self.assertEqual(deferred_job.func, divide)
+        self.assertEqual(deferred_job.args, (1,))
+        self.assertEqual(deferred_job.kwargs, {'b': 1})
+        self.assertEqual(deferred_job.result_ttl, None)
+        self.assertEqual(deferred_job.timeout, queue._default_timeout)
+
+        # enqueue_at is deferred the same way
+        scheduled_at = datetime(2030, 1, 1, tzinfo=timezone.utc)
+        self.assertIsNone(queue.enqueue_at(scheduled_at, say_hello))
+        deferred_queue, method_name, args, kwargs = delayed_queue[1]
+        self.assertIs(deferred_queue, queue)
+        self.assertEqual(method_name, 'enqueue_at')
+        self.assertEqual(args, (scheduled_at, say_hello))
+
+        # enqueue_in goes through RQ's enqueue_at, so it is recorded as 'enqueue_at'
+        # with the target datetime already resolved
+        self.assertIsNone(queue.enqueue_in(timedelta(minutes=1), say_hello))
+        deferred_queue, method_name, args, kwargs = delayed_queue[2]
+        self.assertIs(deferred_queue, queue)
+        self.assertEqual(method_name, 'enqueue_at')
+        self.assertIsInstance(args[0], datetime)
+        self.assertEqual(args[1], say_hello)
+
+        self.assertEqual(queue.count, 0)
+        self.assertEqual(len(ScheduledJobRegistry(queue=queue)), 0)
 
     def test_commit(self):
         """
@@ -89,39 +139,78 @@ class ThreadQueueTest(TestCase):
         delayed_queue.
         """
         queue = get_queue()
+        registry = ScheduledJobRegistry(queue=queue)
         delayed_queue = thread_queue.get_queue()
-        queue.empty()
         self.assertEqual(queue.count, 0)
-        queue.enqueue_call(divide, args=(1,), kwargs={'b': 1})
-        thread_queue.commit()
+
+        fixed_now = datetime(2030, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        delay = timedelta(minutes=5)
+        with mock.patch('rq.queue.now', return_value=fixed_now) as mocked_now:
+            queue.enqueue_call(divide, args=(1,), kwargs={'b': 1})
+            queue.enqueue_in(delay, say_hello)
+            # Time passes before the request finishes
+            mocked_now.return_value = fixed_now + timedelta(hours=1)
+            thread_queue.commit()
+
         self.assertEqual(queue.count, 1)
         self.assertEqual(len(delayed_queue), 0)
+        self.assertEqual(len(registry), 1)
+        # enqueue_in resolves its target time when called, not when committed
+        scheduled_job_id = registry.get_job_ids()[0]
+        self.assertEqual(registry.get_scheduled_time(scheduled_job_id), fixed_now + delay)
 
     def test_clear(self):
         queue = get_queue()
         delayed_queue = thread_queue.get_queue()
-        delayed_queue.append((queue, divide, (1,), {'b': 1}))
+        job = queue.create_job(divide, args=(1,), kwargs={'b': 1})
+        delayed_queue.append((queue, 'enqueue_job', (job,), {}))
         thread_queue.clear()
         delayed_queue = thread_queue.get_queue()
         self.assertEqual(delayed_queue, [])
 
+    def test_enqueue_now(self):
+        """enqueue_now runs RQ's own method right away, ignoring the commit mode."""
+        queue = get_queue()
+        registry = ScheduledJobRegistry(queue=queue)
+        scheduled = queue.enqueue_now('enqueue_at', datetime(2030, 1, 1, tzinfo=timezone.utc), say_hello)
+        self.assertIn(scheduled.id, registry.get_job_ids())
+        self.assertEqual(thread_queue.get_queue(), [])
+
+    def test_explicit_pipeline_runs_immediately(self):
+        """A caller-supplied pipeline is never deferred."""
+        queue = get_queue()
+        registry = ScheduledJobRegistry(queue=queue)
+        with queue.connection.pipeline() as pipeline:
+            job = queue.enqueue(say_hello, pipeline=pipeline)
+            scheduled = queue.enqueue_at(datetime(2030, 1, 1, tzinfo=timezone.utc), say_hello, pipeline=pipeline)
+            self.assertIsNotNone(job)
+            self.assertIsNotNone(scheduled)
+            self.assertEqual(thread_queue.get_queue(), [])
+            # The jobs only reach the queue once the caller executes the pipeline
+            self.assertEqual(queue.count, 0)
+            pipeline.execute()
+
+        self.assertIn(job.id, queue.job_ids)
+        self.assertIn(scheduled.id, registry.get_job_ids())
+
     @override_settings(RQ={'AUTOCOMMIT': False})
     def test_success(self):
         queue = get_queue()
-        queue.empty()
-        thread_queue.clear()
+        registry = ScheduledJobRegistry(queue=queue)
         self.assertEqual(queue.count, 0)
         self.client.get(reverse('success'))
         self.assertEqual(queue.count, 1)
+        self.assertEqual(len(registry), 1)
 
     @override_settings(RQ={'AUTOCOMMIT': False})
     def test_error(self):
         queue = get_queue()
-        queue.empty()
+        registry = ScheduledJobRegistry(queue=queue)
         self.assertEqual(queue.count, 0)
         url = reverse('error')
         self.assertRaises(ValueError, self.client.get, url)
         self.assertEqual(queue.count, 0)
+        self.assertEqual(len(registry), 0)
 
 
 @override_settings(RQ={'COMMIT_MODE': 'on_db_commit'})
@@ -132,65 +221,59 @@ class OnDbCommitTest(TransactionTestCase):
     transaction that never commits, which interferes with on_commit() behavior.
     """
 
+    def setUp(self):
+        self.queue = get_queue()
+        self.registry = ScheduledJobRegistry(queue=self.queue)
+        reset_state(self.queue)
+        self.addCleanup(reset_state, self.queue)
+
+    def enqueue_with_every_api(self):
+        """Call enqueue, enqueue_at and enqueue_in once each, using the API name as the job id."""
+        queue = self.queue
+        job = queue.enqueue(say_hello, job_id='enqueue')
+        scheduled = queue.enqueue_at(datetime(2030, 1, 1, tzinfo=timezone.utc), say_hello, job_id='enqueue_at')
+        delayed = queue.enqueue_in(timedelta(minutes=1), say_hello, job_id='enqueue_in')
+        return job, scheduled, delayed
+
     def test_job_enqueued_after_transaction_commits(self):
-        """Job should be enqueued only after the transaction commits."""
-        queue = get_queue()
-        queue.empty()
-        self.assertEqual(queue.count, 0)
-
+        """Jobs should be enqueued or scheduled only after the transaction commits."""
         with transaction.atomic():
-            job = queue.enqueue(say_hello)
-            # Inside transaction, enqueue returns None (deferred via on_commit)
+            job, scheduled, delayed = self.enqueue_with_every_api()
+            # Inside transaction, every API returns None (deferred via on_commit)
             self.assertIsNone(job)
-            # Job should not be in queue yet (transaction not committed)
-            self.assertEqual(queue.count, 0)
+            self.assertIsNone(scheduled)
+            self.assertIsNone(delayed)
+            self.assertEqual(self.queue.count, 0)
 
-        # After transaction commits, job should be in queue
-        self.assertEqual(queue.count, 1)
+        # After transaction commits, enqueue is queued, enqueue_at + enqueue_in are scheduled
+        self.assertEqual(self.queue.job_ids, ['enqueue'])
+        self.assertEqual(sorted(self.registry.get_job_ids()), ['enqueue_at', 'enqueue_in'])
 
     def test_job_discarded_on_rollback(self):
-        """Job should be discarded if the transaction rolls back."""
-        queue = get_queue()
-        queue.empty()
-        self.assertEqual(queue.count, 0)
-
-        try:
+        """Jobs should be discarded if the transaction rolls back."""
+        with self.assertRaises(RuntimeError):
             with transaction.atomic():
-                queue.enqueue(say_hello)
-                # Job should not be in queue yet
-                self.assertEqual(queue.count, 0)
-                # Force a rollback
-                raise Exception('Forcing rollback')
-        except Exception:
-            pass
+                self.enqueue_with_every_api()
+                self.assertEqual(self.queue.count, 0)
+                raise RuntimeError('Forcing rollback')
 
-        # After rollback, job should NOT be in queue
-        self.assertEqual(queue.count, 0)
+        # After rollback, nothing should be in Redis
+        self.assertEqual(self.queue.count, 0)
 
     def test_job_enqueued_immediately_without_transaction(self):
-        """Job should be enqueued immediately when not in a transaction.
+        """Jobs should be enqueued immediately when not in a transaction.
 
-        When not in an atomic block, enqueue() should return the Job object
-        and enqueue immediately (short-circuit optimization).
+        When not in an atomic block, each API should return the Job object
+        and write to Redis immediately (short-circuit optimization).
         """
-        queue = get_queue()
-        queue.empty()
-        self.assertEqual(queue.count, 0)
-
-        # No transaction context - should enqueue immediately and return Job
-        job = queue.enqueue(say_hello)
-
-        # Job should be returned and in queue immediately
-        self.assertIsNotNone(job)
-        self.assertEqual(queue.count, 1)
-        job.delete()
+        job, scheduled, delayed = self.enqueue_with_every_api()
+        self.assertIn(job.id, self.queue.job_ids)
+        self.assertIn(scheduled.id, self.registry.get_job_ids())
+        self.assertIn(delayed.id, self.registry.get_job_ids())
 
     def test_nested_atomic_blocks(self):
         """Jobs should be enqueued after the outermost transaction commits."""
-        queue = get_queue()
-        queue.empty()
-        self.assertEqual(queue.count, 0)
-
+        queue = self.queue
         with transaction.atomic():
             queue.enqueue(say_hello)
             with transaction.atomic():

--- a/tests/test_django_rq_utils.py
+++ b/tests/test_django_rq_utils.py
@@ -103,6 +103,7 @@ class UtilsTest(TestCase):
         self.assertEqual(data['workers'], 1)
         worker.register_death()
 
+    @override_settings(RQ={'COMMIT_MODE': 'auto'})
     def test_get_jobs(self):
         """get_jobs() works properly"""
         queue = get_queue('django_rq_test')

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import datetime
+from unittest import mock
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -13,7 +14,6 @@ from rq.registry import (
     FailedJobRegistry,
     FinishedJobRegistry,
     ScheduledJobRegistry,
-    StartedJobRegistry,
 )
 
 from django_rq import get_queue
@@ -514,39 +514,16 @@ class ViewTest(TestCase):
             self.assertEqual(response.status_code, 401)
 
     def test_action_stop_jobs(self):
+        """Stopping jobs sends RQ's stop-job command for each selected job."""
         queue = get_queue('django_rq_test')
         queue_index = get_queue_index('django_rq_test')
+        job_ids = [queue.enqueue(access_self).id for _ in range(3)]
 
-        # Enqueue some jobs
-        job_ids, jobs = [], []
-        worker = get_worker('django_rq_test')
-        # Due to implementation details in RQ v2.x, this test only works
-        # with a single job. This test should be changed to use mocks
-        for _ in range(1):
-            job = queue.enqueue(access_self)
-            job_ids.append(job.id)
-            jobs.append(job)
-            worker.prepare_job_execution(job)
-            worker.prepare_execution(job)
-
-        # Check if the jobs are started
-        for job_id in job_ids:
-            job = Job.fetch(job_id, connection=queue.connection)
-            self.assertEqual(job.get_status(), JobStatus.STARTED)
-
-        # Stop those jobs using the view
-        started_job_registry = StartedJobRegistry(queue.name, connection=queue.connection)
-        self.assertEqual(len(started_job_registry), len(job_ids))
-        self.client.post(reverse('admin:django_rq_actions', args=[queue_index]), {'action': 'stop', 'job_ids': job_ids})
-        for job in jobs:
-            worker.monitor_work_horse(job, queue)  # Sets the job as Failed and removes from Started
-        self.assertEqual(len(started_job_registry), 0)
-
-        canceled_job_registry = FailedJobRegistry(queue.name, connection=queue.connection)
-        self.assertEqual(len(canceled_job_registry), len(job_ids))
-
-        for job_id in job_ids:
-            self.assertTrue(job_id in canceled_job_registry)
+        with mock.patch('django_rq.utils.send_stop_job_command') as send_stop_job_command:
+            self.client.post(
+                reverse('admin:django_rq_actions', args=[queue_index]), {'action': 'stop', 'job_ids': job_ids}
+            )
+        self.assertEqual([call.args[1] for call in send_stop_job_command.call_args_list], job_ids)
 
     # def test_scheduler_jobs(self):
     #     # Override testing RQ_QUEUES

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from django.shortcuts import render
 
 from django_rq import get_queue
@@ -10,10 +12,12 @@ def say_hello():
 def success(request):
     queue = get_queue()
     queue.enqueue(say_hello)
+    queue.enqueue_in(timedelta(minutes=1), say_hello)
     return render(request, 'django_rq/test.html', {})
 
 
 def error(request):
     queue = get_queue()
     queue.enqueue(say_hello)
+    queue.enqueue_in(timedelta(minutes=1), say_hello)
     raise ValueError


### PR DESCRIPTION
Fixes https://github.com/rq/django-rq/issues/821

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Job enqueueing now consistently supports automatic, database-commit, and request-finished execution modes.
  * Jobs submitted with an explicit pipeline execute immediately.
  * Immediate and scheduled job submissions now follow the same deferral behavior.
  * Deferred jobs are reliably dispatched after successful commits and remain unqueued after rollbacks.
* **Tests**
  * Expanded coverage for commit modes, nested transactions, scheduled jobs, pipelines, and job-stop actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->